### PR TITLE
Fixwarn

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,14 +51,14 @@ ENDIF()
 
 
 INCLUDE_DIRECTORIES( BEFORE ./include )
-INCLUDE_DIRECTORIES( ${ROOT_INCLUDE_DIRS} )
+INCLUDE_DIRECTORIES( SYSTEM ${ROOT_INCLUDE_DIRS} )
 INSTALL_DIRECTORY( ./include DESTINATION . FILES_MATCHING PATTERN "*.h" )
 
 
 
-#ADD_DEFINITIONS( "-Wall -ansi" ) # -pedantic" )
-#ADD_DEFINITIONS( "-Wno-long-long" )
-
+#FIXME: silence the eccessive warnings for now
+#       should be addressed later - if needed
+ADD_DEFINITIONS( "-Wno-effc++ -Wno-unused-parameter -Wno-vla" )
 
 
 # verbose debug mode

--- a/include/RAIDA/IFunctionROOT.h
+++ b/include/RAIDA/IFunctionROOT.h
@@ -23,7 +23,7 @@ class IAnnotation;
  * @version $Id: IFunctionROOT.h,v 1.2 2007-01-02 16:20:45 tkraemer Exp $
  */
  
-class IFunctionROOT : public IFunction {
+class IFunctionROOT : virtual public IFunction {
 
 public: 
   /// Destructor.


### PR DESCRIPTION
BEGINRELEASENOTES 
- silence warnings: effc++, unused, vla 
- fix virtual inheritance in IFunctionROOT

ENDRELEASENOTES


