### PR TITLE
Make the provided AIDA headers compatible with AIDA

### DIFF
--- a/include/AIDA/IBaseHistogram.h
+++ b/include/AIDA/IBaseHistogram.h
@@ -16,7 +16,7 @@
 
 namespace AIDA {
 
-  /// class IAnnotation;
+class IAnnotation;
 
 /**
  * User level interface to Histogram.
@@ -82,7 +82,7 @@ public:
    * @param className The name of the class to cast on.
    * @return The right pointer. Return 0 if failure.
    */ 
-  /// virtual void * cast(const std::string & className) const = 0;
+    virtual void * cast(const std::string & className) const = 0;
 }; // class
 } // namespace AIDA
 #endif /* ifndef AIDA_IBASEHISTOGRAM_H */

--- a/include/AIDA/IBaseHistogram.h
+++ b/include/AIDA/IBaseHistogram.h
@@ -52,9 +52,9 @@ public:
    * @return The IAnnotation.
    *
    */
-  /// virtual IAnnotation & annotation() = 0;
+  virtual IAnnotation & annotation() = 0;
 
-  /// virtual const IAnnotation & annotation() const = 0;
+  virtual const IAnnotation & annotation() const = 0;
 
   /**
    * Get the Histogram's dimension.

--- a/include/AIDA/ICloud1D.h
+++ b/include/AIDA/ICloud1D.h
@@ -127,7 +127,7 @@ public:
      * @return false If the ICloud1D has already been converted.
      *
      */
-  /// virtual bool convert(const std::vector<double>  & binEdges) = 0;
+    virtual bool convert(const std::vector<double>  & binEdges) = 0;
 
     /**
      * Get the internal IHistogram1D in which the ICloud1D converted to.

--- a/include/AIDA/ICloud2D.h
+++ b/include/AIDA/ICloud2D.h
@@ -179,7 +179,7 @@ public:
      * @return false If the ICloud2D has already been converted.
      *
      */
-  /// virtual bool convert(const std::vector<double>  & binEdgesX, const std::vector<double>  & binEdgesY) = 0;
+    virtual bool convert(const std::vector<double>  & binEdgesX, const std::vector<double>  & binEdgesY) = 0;
 
     /**     
      * Get the internal IHistogram2D in which the ICloud2D converted to.

--- a/include/AIDA/ICloud3D.h
+++ b/include/AIDA/ICloud3D.h
@@ -231,7 +231,7 @@ public:
      * @return false If the ICloud3D has already been converted.
      *
      */
-  /// virtual bool convert(const std::vector<double>  & binEdgesX, const std::vector<double>  & binEdgesY, const std::vector<double>  & binEdgesZ) = 0;
+    virtual bool convert(const std::vector<double>  & binEdgesX, const std::vector<double>  & binEdgesY, const std::vector<double>  & binEdgesZ) = 0;
 
     /**     
      * Get the internal IHistogram3D in which the ICloud3D converted to.

--- a/include/AIDA/IDataPointSetFactory.h
+++ b/include/AIDA/IDataPointSetFactory.h
@@ -52,7 +52,7 @@ public:
      * @return            The newly created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * create(const std::string & path, const std::string & title, int dimOfPoints) = 0;
+    virtual IDataPointSet * create(const std::string & path, const std::string & title, int dimOfPoints) = 0;
 
     /**
      * Create an empty IDataPointSet.
@@ -65,7 +65,7 @@ public:
      * @return             The newly created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * create(const std::string & pathAndTitle, int dimOfPoints) = 0;
+    virtual IDataPointSet * create(const std::string & pathAndTitle, int dimOfPoints) = 0;
 
     /**
      * Create a two dimensional IDataPointSet providing the data along y (the x value is 
@@ -80,7 +80,7 @@ public:
      * @return      The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createY(const std::string & path, const std::string & title, const std::vector<double>  & y, const std::vector<double>  & ey) = 0;
+    virtual IDataPointSet * createY(const std::string & path, const std::string & title, const std::vector<double>  & y, const std::vector<double>  & ey) = 0;
 
     /**
      * Create a two dimensional IDataPointSet providing the data along y (the x value is 
@@ -96,7 +96,7 @@ public:
      * @return      The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createY(const std::string & path, const std::string & title, const std::vector<double>  & y, const std::vector<double>  & eyp, const std::vector<double>  & eym) = 0;
+    virtual IDataPointSet * createY(const std::string & path, const std::string & title, const std::vector<double>  & y, const std::vector<double>  & eyp, const std::vector<double>  & eym) = 0;
 
     /**
      * Create a two dimensional IDataPointSet providing the data along y (the x value is 
@@ -111,7 +111,7 @@ public:
      * @return             The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createY(const std::string & pathAndTitle, const std::vector<double>  & y, const std::vector<double>  & ey) = 0;
+    virtual IDataPointSet * createY(const std::string & pathAndTitle, const std::vector<double>  & y, const std::vector<double>  & ey) = 0;
 
     /**
      * Create a two dimensional IDataPointSet providing the data along y (the x value is 
@@ -127,7 +127,7 @@ public:
      * @return             The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createY(const std::string & pathAndTitle, const std::vector<double>  & y, const std::vector<double>  & eyp, const std::vector<double>  & eym) = 0;
+    virtual IDataPointSet * createY(const std::string & pathAndTitle, const std::vector<double>  & y, const std::vector<double>  & eyp, const std::vector<double>  & eym) = 0;
 
     /**
      * Create a two dimensional IDataPointSet providing the data along x (the y value is 
@@ -142,7 +142,7 @@ public:
      * @return      The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createX(const std::string & path, const std::string & title, const std::vector<double>  & x, const std::vector<double>  & ex) = 0;
+    virtual IDataPointSet * createX(const std::string & path, const std::string & title, const std::vector<double>  & x, const std::vector<double>  & ex) = 0;
 
     /**
      * Create a two dimensional IDataPointSet providing the data along x (the y value is 
@@ -158,7 +158,7 @@ public:
      * @return      The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createX(const std::string & path, const std::string & title, const std::vector<double>  & x, const std::vector<double>  & exp, const std::vector<double>  & exm) = 0;
+    virtual IDataPointSet * createX(const std::string & path, const std::string & title, const std::vector<double>  & x, const std::vector<double>  & exp, const std::vector<double>  & exm) = 0;
 
     /**
      * Create a two dimensional IDataPointSet providing the data along x (the y value is 
@@ -173,7 +173,7 @@ public:
      * @return             The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createX(const std::string & pathAndTitle, const std::vector<double>  & x, const std::vector<double>  & ex) = 0;
+    virtual IDataPointSet * createX(const std::string & pathAndTitle, const std::vector<double>  & x, const std::vector<double>  & ex) = 0;
 
     /**
      * Create a two dimensional IDataPointSet providing the data along x (the y value is 
@@ -189,7 +189,7 @@ public:
      * @return             The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createX(const std::string & pathAndTitle, const std::vector<double>  & x, const std::vector<double>  & exp, const std::vector<double>  & exm) = 0;
+    virtual IDataPointSet * createX(const std::string & pathAndTitle, const std::vector<double>  & x, const std::vector<double>  & exp, const std::vector<double>  & exm) = 0;
 
     /**
      * Create a two dimensional IDataPointSet providing the data.
@@ -207,7 +207,7 @@ public:
      * @return      The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createXY(const std::string & path, const std::string & title, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & exp, const std::vector<double>  & eyp, const std::vector<double>  & exm, const std::vector<double>  & eym) = 0;
+    virtual IDataPointSet * createXY(const std::string & path, const std::string & title, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & exp, const std::vector<double>  & eyp, const std::vector<double>  & exm, const std::vector<double>  & eym) = 0;
 
     /**
      * Create a two dimensional IDataPointSet providing the data.
@@ -223,7 +223,7 @@ public:
      * @return      The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createXY(const std::string & path, const std::string & title, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & ex, const std::vector<double>  & ey) = 0;
+    virtual IDataPointSet * createXY(const std::string & path, const std::string & title, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & ex, const std::vector<double>  & ey) = 0;
 
     /**
      * Create a two dimensional IDataPointSet providing the data.
@@ -241,7 +241,7 @@ public:
      * @return             The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createXY(const std::string & pathAndTitle, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & exp, const std::vector<double>  & eyp, const std::vector<double>  & exm, const std::vector<double>  & eym) = 0;
+    virtual IDataPointSet * createXY(const std::string & pathAndTitle, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & exp, const std::vector<double>  & eyp, const std::vector<double>  & exm, const std::vector<double>  & eym) = 0;
 
     /**
      * Create a two dimensional IDataPointSet providing the data.
@@ -257,7 +257,7 @@ public:
      * @return             The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createXY(const std::string & pathAndTitle, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & ex, const std::vector<double>  & ey) = 0;
+    virtual IDataPointSet * createXY(const std::string & pathAndTitle, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & ex, const std::vector<double>  & ey) = 0;
 
     /**
      * Create a three dimensional IDataPointSet providing the data.
@@ -278,7 +278,7 @@ public:
      * @return      The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createXYZ(const std::string & path, const std::string & title, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & z, const std::vector<double>  & exp, const std::vector<double>  & eyp, const std::vector<double>  & ezp, const std::vector<double>  & exm, const std::vector<double>  & eym, const std::vector<double>  & ezm) = 0;
+    virtual IDataPointSet * createXYZ(const std::string & path, const std::string & title, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & z, const std::vector<double>  & exp, const std::vector<double>  & eyp, const std::vector<double>  & ezp, const std::vector<double>  & exm, const std::vector<double>  & eym, const std::vector<double>  & ezm) = 0;
 
     /**
      * Create a three dimensional IDataPointSet providing the data.
@@ -296,7 +296,7 @@ public:
      * @return      The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createXYZ(const std::string & path, const std::string & title, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & z, const std::vector<double>  & ex, const std::vector<double>  & ey, const std::vector<double>  & ez) = 0;
+    virtual IDataPointSet * createXYZ(const std::string & path, const std::string & title, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & z, const std::vector<double>  & ex, const std::vector<double>  & ey, const std::vector<double>  & ez) = 0;
 
     /**
      * Create a two dimensional IDataPointSet providing the data.
@@ -317,7 +317,7 @@ public:
      * @return             The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createXYZ(const std::string & pathAndTitle, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & z, const std::vector<double>  & exp, const std::vector<double>  & eyp, const std::vector<double>  & ezp, const std::vector<double>  & exm, const std::vector<double>  & eym, const std::vector<double>  & ezm) = 0;
+    virtual IDataPointSet * createXYZ(const std::string & pathAndTitle, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & z, const std::vector<double>  & exp, const std::vector<double>  & eyp, const std::vector<double>  & ezp, const std::vector<double>  & exm, const std::vector<double>  & eym, const std::vector<double>  & ezm) = 0;
 
     /**
      * Create a two dimensional IDataPointSet providing the data.
@@ -335,7 +335,7 @@ public:
      * @return             The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createXYZ(const std::string & pathAndTitle, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & z, const std::vector<double>  & ex, const std::vector<double>  & ey, const std::vector<double>  & ez) = 0;
+    virtual IDataPointSet * createXYZ(const std::string & pathAndTitle, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & z, const std::vector<double>  & ex, const std::vector<double>  & ey, const std::vector<double>  & ez) = 0;
 
     /**
      * Make a copy of a given IDataPointSet.
@@ -347,7 +347,7 @@ public:
      * @return             The copy of the given IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createCopy(const std::string & path, const IDataPointSet & dataPointSet) = 0;
+    virtual IDataPointSet * createCopy(const std::string & path, const IDataPointSet & dataPointSet) = 0;
 
     /**
      * Destroy a given IDataPointSet.
@@ -355,7 +355,7 @@ public:
      * @return false If dataPointSet cannot be destroyed.
      *
      */
-  ///virtual bool destroy(IDataPointSet * dataPointSet) = 0;
+    virtual bool destroy(IDataPointSet * dataPointSet) = 0;
 
     /**
      * Create an IDataPointSet from an IHistogram1D.
@@ -368,7 +368,7 @@ public:
      * @return        The newly created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * create(const std::string & path, const IHistogram1D & hist, const std::string & options = "") = 0;
+    virtual IDataPointSet * create(const std::string & path, const IHistogram1D & hist, const std::string & options = "") = 0;
 
     /**
      * Create an IDataPointSet from an IHistogram2D.
@@ -381,7 +381,7 @@ public:
      * @return        The newly created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * create(const std::string & path, const IHistogram2D & hist, const std::string & options = "") = 0;
+    virtual IDataPointSet * create(const std::string & path, const IHistogram2D & hist, const std::string & options = "") = 0;
 
     /**
      * Create an IDataPointSet from an IHistogram3D.
@@ -394,7 +394,7 @@ public:
      * @return        The newly created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * create(const std::string & path, const IHistogram3D & hist, const std::string & options = "") = 0;
+    virtual IDataPointSet * create(const std::string & path, const IHistogram3D & hist, const std::string & options = "") = 0;
 
     /**
      * Create an IDataPointSet from an ICloud1D.
@@ -407,7 +407,7 @@ public:
      * @return        The newly created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * create(const std::string & path, const ICloud1D & cloud, const std::string & options = "") = 0;
+    virtual IDataPointSet * create(const std::string & path, const ICloud1D & cloud, const std::string & options = "") = 0;
 
     /**
      * Create an IDataPointSet from an ICloud2D.
@@ -420,7 +420,7 @@ public:
      * @return        The newly created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * create(const std::string & path, const ICloud2D & cloud, const std::string & options = "") = 0;
+    virtual IDataPointSet * create(const std::string & path, const ICloud2D & cloud, const std::string & options = "") = 0;
 
     /**
      * Create an IDataPointSet from an ICloud3D.
@@ -433,7 +433,7 @@ public:
      * @return        The newly created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * create(const std::string & path, const ICloud3D & cloud, const std::string & options = "") = 0;
+    virtual IDataPointSet * create(const std::string & path, const ICloud3D & cloud, const std::string & options = "") = 0;
 
     /**
      * Create an IDataPointSet from an IProfile1D.
@@ -446,7 +446,7 @@ public:
      * @return        The newly created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * create(const std::string & path, const IProfile1D & profile, const std::string & options = "") = 0;
+    virtual IDataPointSet * create(const std::string & path, const IProfile1D & profile, const std::string & options = "") = 0;
 
     /**
      * Create an IDataPointSet from an IProfile2D.
@@ -459,7 +459,7 @@ public:
      * @return        The newly created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * create(const std::string & path, const IProfile2D & profile, const std::string & options = "") = 0;
+    virtual IDataPointSet * create(const std::string & path, const IProfile2D & profile, const std::string & options = "") = 0;
 
     /**
      * Add two IDataSetPoint, point by point and measurement by measurement.
@@ -472,7 +472,7 @@ public:
      *                      if a directory in the path does not exist, or the path is illegal.
      *
      */
-  ///virtual IDataPointSet * add(const std::string & path, const IDataPointSet & dataPointSet1, const IDataPointSet & dataPointSet2) = 0;
+    virtual IDataPointSet * add(const std::string & path, const IDataPointSet & dataPointSet1, const IDataPointSet & dataPointSet2) = 0;
 
     /**
      * Subtract two IDataSetPoint, point by point and measurement by measurement.
@@ -487,7 +487,7 @@ public:
      *                      if a directory in the path does not exist, or the path is illegal.
      *
      */
-  ///virtual IDataPointSet * subtract(const std::string & path, const IDataPointSet & dataPointSet1, const IDataPointSet & dataPointSet2) = 0;
+    virtual IDataPointSet * subtract(const std::string & path, const IDataPointSet & dataPointSet1, const IDataPointSet & dataPointSet2) = 0;
 
     /**
      * Multiply two IDataSetPoint, point by point and measurement by measurement.
@@ -502,7 +502,7 @@ public:
      *                      if a directory in the path does not exist, or the path is illegal.
      *
      */
-  ///virtual IDataPointSet * multiply(const std::string & path, const IDataPointSet & dataPointSet1, const IDataPointSet & dataPointSet2) = 0;
+    virtual IDataPointSet * multiply(const std::string & path, const IDataPointSet & dataPointSet1, const IDataPointSet & dataPointSet2) = 0;
 
     /**
      * Divide two IDataSetPoint, point by point and measurement by measurement.
@@ -517,7 +517,7 @@ public:
      *                      if a directory in the path does not exist, or the path is illegal.
      *
      */
-  ///virtual IDataPointSet * divide(const std::string & path, const IDataPointSet & dataPointSet1, const IDataPointSet & dataPointSet2) = 0;
+    virtual IDataPointSet * divide(const std::string & path, const IDataPointSet & dataPointSet1, const IDataPointSet & dataPointSet2) = 0;
 
     /**
      * Calculate weighted means of two IDataSetPoint, point by point and measurement by measurement.
@@ -532,7 +532,7 @@ public:
      *                      if a directory in the path does not exist, or the path is illegal.
      *
      */
-  ///virtual IDataPointSet * weightedMean(const std::string & path, const IDataPointSet & dataPointSet1, const IDataPointSet & dataPointSet2) = 0;
+    virtual IDataPointSet * weightedMean(const std::string & path, const IDataPointSet & dataPointSet1, const IDataPointSet & dataPointSet2) = 0;
 }; // class
 } // namespace AIDA
 #endif /* ifndef AIDA_IDATAPOINTSETFACTORY_H */

--- a/include/AIDA/IFunctionFactory.h
+++ b/include/AIDA/IFunctionFactory.h
@@ -48,7 +48,7 @@ public:
      * @return      The newly created function.
      *
      */
-  /// virtual IFunction * createFunctionByName(const std::string & path, const std::string & model) = 0;
+    virtual IFunction * createFunctionByName(const std::string & path, const std::string & model) = 0;
 
     /**
      * Create function from script. Script conventions:
@@ -66,7 +66,7 @@ public:
      *                    provided expressions is illigal.
      *
      */
-  /// virtual IFunction * createFunctionFromScript(const std::string & name, int dim, const std::string & valexpr, const std::string & parameters, const std::string & description, const std::string & gradexpr = "") = 0;
+    virtual IFunction * createFunctionFromScript(const std::string & name, int dim, const std::string & valexpr, const std::string & parameters, const std::string & description, const std::string & gradexpr = "") = 0;
 
     /**
      * Create a clone of an existing function.
@@ -78,12 +78,12 @@ public:
      * @return     The clone of the provided IFunction.
      *
      */
-  /// virtual IFunction * cloneFunction(const std::string & path, IFunction & f) = 0;
+    virtual IFunction * cloneFunction(const std::string & path, IFunction & f) = 0;
 
     /**
      * get access to the function catalog
      */
-  /// virtual IFunctionCatalog * catalog() = 0;
+    virtual IFunctionCatalog * catalog() = 0;
 
     /** @link association 
      * @directed*/

--- a/include/AIDA/IHistogram.h
+++ b/include/AIDA/IHistogram.h
@@ -51,7 +51,7 @@ public:
      * @return The number of equivalent entries.
      *
      */
-  /// virtual double equivalentBinEntries() const = 0;
+    virtual double equivalentBinEntries() const = 0;
 
     /**
      * Sum of in-range bin heights in the IHistogram,

--- a/include/AIDA/IHistogramFactory.h
+++ b/include/AIDA/IHistogramFactory.h
@@ -63,10 +63,7 @@ public:
      * @return        The newly created ICloud1D.
      *
      */
-  virtual ICloud1D * createCloud1D(const std::string & path, 
-                                   const std::string & title, 
-                                   int nMax = -1, 
-                                   const std::string & options = "") = 0;
+    virtual ICloud1D * createCloud1D(const std::string & path, const std::string & title, int nMax = -1, const std::string & options = "") = 0;
 
     /**
      * Create a ICloud1D, an unbinned 1-dimensional histogram.
@@ -90,8 +87,7 @@ public:
      * @return        The copy of the ICloud1D.
      *
      */
-  virtual ICloud1D * createCopy(const std::string & path, 
-				const ICloud1D & cloud) = 0;
+    virtual ICloud1D * createCopy(const std::string & path, const ICloud1D & cloud) = 0;
 
     /**
      * Create a ICloud2D, an unbinned 2-dimensional histogram.
@@ -107,10 +103,7 @@ public:
      * @return        The newly created ICloud2D.
      *
      */
-  virtual ICloud2D * createCloud2D(const std::string & path, 
-				   const std::string & title, 
-				   int nMax = -1, 
-				   const std::string & options = "") = 0;
+    virtual ICloud2D * createCloud2D(const std::string & path, const std::string & title, int nMax = -1, const std::string & options = "") = 0;
 
     /**
      * Create a ICloud2D, an unbinned 2-dimensional histogram.
@@ -134,8 +127,7 @@ public:
      * @return        The copy of the ICloud2D.
      *
      */
-  virtual ICloud2D * createCopy(const std::string & path, 
-				const ICloud2D & cloud) = 0;
+    virtual ICloud2D * createCopy(const std::string & path, const ICloud2D & cloud) = 0;
 
     /**
      * Create a ICloud3D, an unbinned 3-dimensional histogram.
@@ -151,10 +143,7 @@ public:
      * @return        The newly created ICloud3D.
      *
      */
-  virtual ICloud3D * createCloud3D(const std::string & path, 
-				   const std::string & title, 
-				   int nMax = -1, 
-				   const std::string & options = "") = 0;
+    virtual ICloud3D * createCloud3D(const std::string & path, const std::string & title, int nMax = -1, const std::string & options = "") = 0;
 
     /**
      * Create a ICloud3D, an unbinned 3-dimensional histogram.
@@ -178,8 +167,7 @@ public:
      * @return        The copy of the ICloud3D.
      *
      */
-  virtual ICloud3D * createCopy(const std::string & path, 
-				const ICloud3D & cloud) = 0;
+    virtual ICloud3D * createCopy(const std::string & path, const ICloud3D & cloud) = 0;
 
     /**
      * Create a IHistogram1D.
@@ -196,12 +184,7 @@ public:
      * @return          The newly created IHistogram1D.
      *
      */
-  virtual IHistogram1D * createHistogram1D(const std::string & path, 
-					   const std::string & title, 
-					   int nBins, 
-					   double lowerEdge, 
-					   double upperEdge, 
-					   const std::string & options = "") = 0;
+    virtual IHistogram1D * createHistogram1D(const std::string & path, const std::string & title, int nBins, double lowerEdge, double upperEdge, const std::string & options = "") = 0;
 
     /**
      * Create a IHistogram1D.
@@ -216,10 +199,7 @@ public:
      * @return             The newly created IHistogram1D.
      *
      */
-  virtual IHistogram1D * createHistogram1D(const std::string & pathAndTitle, 
-					   int nBins, 
-					   double lowerEdge, 
-					   double upperEdge) = 0;
+    virtual IHistogram1D * createHistogram1D(const std::string & pathAndTitle, int nBins, double lowerEdge, double upperEdge) = 0;
 
     /**
      * Create a IHistogram1D.
@@ -234,10 +214,7 @@ public:
      * @return          The newly created IHistogram1D.
      *
      */
-  virtual IHistogram1D * createHistogram1D(const std::string & path, 
-					   const std::string & title, 
-					   const std::vector<double>  & binEdges, 
-					   const std::string & options = "") = 0;
+    virtual IHistogram1D * createHistogram1D(const std::string & path, const std::string & title, const std::vector<double>  & binEdges, const std::string & options = "") = 0;
 
     /**
      * Create a copy of an IHistogram1D.
@@ -249,8 +226,7 @@ public:
      * @return     The copy of the IHistogram1D.
      *
      */
-  virtual IHistogram1D * createCopy(const std::string & path, 
-				    const IHistogram1D & hist) = 0;
+    virtual IHistogram1D * createCopy(const std::string & path, const IHistogram1D & hist) = 0;
 
     /**
      * Create a IHistogram2D.
@@ -270,15 +246,7 @@ public:
      * @return           The newly created IHistogram2D.
      *
      */
-  virtual IHistogram2D * createHistogram2D(const std::string & path, 
-                                           const std::string & title, 
-                                           int nBinsX, 
-                                           double lowerEdgeX, 
-                                           double upperEdgeX, 
-                                           int nBinsY, 
-                                           double lowerEdgeY, 
-                                           double upperEdgeY, 
-                                           const std::string & options = "") = 0;
+    virtual IHistogram2D * createHistogram2D(const std::string & path, const std::string & title, int nBinsX, double lowerEdgeX, double upperEdgeX, int nBinsY, double lowerEdgeY, double upperEdgeY, const std::string & options = "") = 0;
 
     /**
      * Create a IHistogram2D.
@@ -296,13 +264,7 @@ public:
      * @return             The newly created IHistogram2D.
      *
      */
-  virtual IHistogram2D * createHistogram2D(const std::string & pathAndTitle, 
-					   int nBinsX, 
-					   double lowerEdgeX, 
-					   double upperEdgeX, 
-					   int nBinsY, 
-					   double lowerEdgeY, 
-					   double upperEdgeY) = 0;
+    virtual IHistogram2D * createHistogram2D(const std::string & pathAndTitle, int nBinsX, double lowerEdgeX, double upperEdgeX, int nBinsY, double lowerEdgeY, double upperEdgeY) = 0;
 
     /**
      * Create a IHistogram2D.
@@ -318,11 +280,7 @@ public:
      * @return           The newly created IHistogram2D.
      *
      */
-  virtual IHistogram2D * createHistogram2D(const std::string & path, 
-					   const std::string & title, 
-					   const std::vector<double>  & binEdgesX, 
-					   const std::vector<double>  & binEdgesY, 
-					   const std::string & options = "") = 0;
+    virtual IHistogram2D * createHistogram2D(const std::string & path, const std::string & title, const std::vector<double>  & binEdgesX, const std::vector<double>  & binEdgesY, const std::string & options = "") = 0;
 
     /**
      * Create a copy of an IHistogram2D.
@@ -334,8 +292,7 @@ public:
      * @return     The copy of the IHistogram2D.
      *
      */
-  virtual IHistogram2D * createCopy(const std::string & path, 
-				    const IHistogram2D & hist) = 0;
+    virtual IHistogram2D * createCopy(const std::string & copy, const IHistogram2D & hist) = 0;
 
     /**
      * Create a IHistogram3D.
@@ -358,18 +315,7 @@ public:
      * @return           The newly created IHistogram3D.
      *
      */
-  virtual IHistogram3D * createHistogram3D(const std::string & path, 
-					   const std::string & title, 
-					   int nBinsX, 
-					   double lowerEdgeX, 
-					   double upperEdgeX, 
-					   int nBinsY, 
-					   double lowerEdgeY, 
-					   double upperEdgeY, 
-					   int nBinsZ, 
-					   double lowerEdgeZ, 
-					   double upperEdgeZ, 
-					   const std::string & options = "") = 0;
+    virtual IHistogram3D * createHistogram3D(const std::string & path, const std::string & title, int nBinsX, double lowerEdgeX, double upperEdgeX, int nBinsY, double lowerEdgeY, double upperEdgeY, int nBinsZ, double lowerEdgeZ, double upperEdgeZ, const std::string & options = "") = 0;
 
     /**
      * Create a IHistogram3D.
@@ -390,16 +336,7 @@ public:
      * @return             The newly created IHistogram3D.
      *
      */
-  virtual IHistogram3D * createHistogram3D(const std::string & pathAndTitle, 
-					   int nBinsX, 
-					   double lowerEdgeX, 
-					   double upperEdgeX, 
-					   int nBinsY, 
-					   double lowerEdgeY, 
-					   double upperEdgeY, 
-					   int nBinsZ, 
-					   double lowerEdgeZ, 
-					   double upperEdgeZ) = 0;
+    virtual IHistogram3D * createHistogram3D(const std::string & pathAndTitle, int nBinsX, double lowerEdgeX, double upperEdgeX, int nBinsY, double lowerEdgeY, double upperEdgeY, int nBinsZ, double lowerEdgeZ, double upperEdgeZ) = 0;
 
     /**
      * Create a IHistogram3D.
@@ -416,12 +353,7 @@ public:
      * @return           The newly created IHistogram3D.
      *
      */
-  virtual IHistogram3D * createHistogram3D(const std::string & path, 
-					   const std::string & title, 
-					   const std::vector<double>  & binEdgesX, 
-					   const std::vector<double>  & binEdgesY, 
-					   const std::vector<double>  & binEdgesZ, 
-					   const std::string & options = "") = 0;
+    virtual IHistogram3D * createHistogram3D(const std::string & path, const std::string & title, const std::vector<double>  & binEdgesX, const std::vector<double>  & binEdgesY, const std::vector<double>  & binEdgesZ, const std::string & options = "") = 0;
 
     /**
      * Create a copy of an IHistogram3D.
@@ -433,8 +365,7 @@ public:
      * @return     The copy of the IHistogram3D.
      *
      */
-  virtual IHistogram3D * createCopy(const std::string & path, 
-				    const IHistogram3D & hist) = 0;
+    virtual IHistogram3D * createCopy(const std::string & path, const IHistogram3D & hist) = 0;
 
     /**
      * Create a IProfile1D.
@@ -450,12 +381,7 @@ public:
      * @return          The newly created IProfile1D.
      *
      */
-  virtual IProfile1D * createProfile1D(const std::string & path, 
-				       const std::string & title, 
-				       int nBins, 
-				       double lowerEdge, 
-				       double upperEdge, 
-				       const std::string & options = "") = 0;
+    virtual IProfile1D * createProfile1D(const std::string & path, const std::string & title, int nBins, double lowerEdge, double upperEdge, const std::string & options = "") = 0;
 
     /**
      * Create a IProfile1D.
@@ -473,14 +399,7 @@ public:
      * @return           The newly created IProfile1D.
      *
      */
-  virtual IProfile1D * createProfile1D(const std::string & path, 
-				       const std::string & title, 
-				       int nBins, 
-				       double lowerEdge, 
-				       double upperEdge, 
-				       double lowerValue, 
-				       double upperValue, 
-				       const std::string & options = "") = 0;
+    virtual IProfile1D * createProfile1D(const std::string & path, const std::string & title, int nBins, double lowerEdge, double upperEdge, double lowerValue, double upperValue, const std::string & options = "") = 0;
 
     /**
      * Create a IProfile1D.
@@ -494,10 +413,7 @@ public:
      * @return          The newly created IProfile1D.
      *
      */
-  virtual IProfile1D * createProfile1D(const std::string & path, 
-				       const std::string & title, 
-				       const std::vector<double>  & binEdges, 
-				       const std::string & options = "") = 0;
+    virtual IProfile1D * createProfile1D(const std::string & path, const std::string & title, const std::vector<double>  & binEdges, const std::string & options = "") = 0;
 
     /**
      * Create a IProfile1D.
@@ -513,12 +429,7 @@ public:
      * @return           The newly created IProfile1D.
      *
      */
-  virtual IProfile1D * createProfile1D(const std::string & path, 
-				       const std::string & title, 
-				       const std::vector<double>  & binEdges, 
-				       double lowerValue, 
-				       double upperValue, 
-				       const std::string & options = "") = 0;
+    virtual IProfile1D * createProfile1D(const std::string & path, const std::string & title, const std::vector<double>  & binEdges, double lowerValue, double upperValue, const std::string & options = "") = 0;
 
     /**
      * Create a IProfile1D.
@@ -533,10 +444,7 @@ public:
      * @return             The newly created IProfile1D.
      *
      */
-  virtual IProfile1D * createProfile1D(const std::string & pathAndTitle, 
-				       int nBins, 
-				       double lowerEdge, 
-				       double upperEdge) = 0;
+    virtual IProfile1D * createProfile1D(const std::string & pathAndTitle, int nBins, double lowerEdge, double upperEdge) = 0;
 
     /**
      * Create a IProfile1D.
@@ -553,12 +461,7 @@ public:
      * @return             The newly created IProfile1D.
      *
      */
-  virtual IProfile1D * createProfile1D(const std::string & pathAndTitle, 
-				       int nBins, 
-				       double lowerEdge, 
-				       double upperEdge, 
-				       double lowerValue, 
-				       double upperValue) = 0;
+    virtual IProfile1D * createProfile1D(const std::string & pathAndTitle, int nBins, double lowerEdge, double upperEdge, double lowerValue, double upperValue) = 0;
 
     /**
      * Create a copy of an IProfile1D.
@@ -570,8 +473,7 @@ public:
      * @return        The copy of the IProfile1D.
      *
      */
-  virtual IProfile1D * createCopy(const std::string & path, 
-				  const IProfile1D & profile) = 0;
+    virtual IProfile1D * createCopy(const std::string & path, const IProfile1D & profile) = 0;
 
     /**
      * Create a IProfile2D.
@@ -590,15 +492,7 @@ public:
      * @return           The newly created IProfile2D.
      *
      */
-  virtual IProfile2D * createProfile2D(const std::string & path, 
-				       const std::string & title, 
-				       int nBinsX, 
-				       double lowerEdgeX, 
-				       double upperEdgeX, 
-				       int nBinsY, 
-				       double lowerEdgeY, 
-				       double upperEdgeY, 
-				       const std::string & options = "") = 0;
+    virtual IProfile2D * createProfile2D(const std::string & path, const std::string & title, int nBinsX, double lowerEdgeX, double upperEdgeX, int nBinsY, double lowerEdgeY, double upperEdgeY, const std::string & options = "") = 0;
 
     /**
      * Create a IProfile2D.
@@ -619,17 +513,7 @@ public:
      * @return           The newly created IProfile2D.
      *
      */
-  virtual IProfile2D * createProfile2D(const std::string & path, 
-				       const std::string & title, 
-				       int nBinsX, 
-				       double lowerEdgeX, 
-				       double upperEdgeX, 
-				       int nBinsY, 
-				       double lowerEdgeY, 
-				       double upperEdgeY, 
-				       double lowerValue, 
-				       double upperValue, 
-				       const std::string & options = "") = 0;
+    virtual IProfile2D * createProfile2D(const std::string & path, const std::string & title, int nBinsX, double lowerEdgeX, double upperEdgeX, int nBinsY, double lowerEdgeY, double upperEdgeY, double lowerValue, double upperValue, const std::string & options = "") = 0;
 
     /**
      * Create a IProfile2D.
@@ -665,13 +549,7 @@ public:
      * @return           The newly created IProfile2D.
      *
      */
-  virtual IProfile2D * createProfile2D(const std::string & path, 
-				       const std::string & title, 
-				       const std::vector<double>  & binEdgesX, 
-				       const std::vector<double>  & binEdgesY, 
-				       double lowerValue, 
-				       double upperValue, 
-				       const std::string & options = "") = 0;
+    virtual IProfile2D * createProfile2D(const std::string & path, const std::string & title, const std::vector<double>  & binEdgesX, const std::vector<double>  & binEdgesY, double lowerValue, double upperValue, const std::string & options = "") = 0;
 
     /**
      * Create a IProfile2D.
@@ -689,13 +567,7 @@ public:
      * @return             The newly created IProfile2D.
      *
      */
-  virtual IProfile2D * createProfile2D(const std::string & pathAndTitle, 
-				       int nBinsX, 
-				       double lowerEdgeX, 
-				       double upperEdgeX, 
-				       int nBinsY, 
-				       double lowerEdgeY, 
-				       double upperEdgeY) = 0;
+    virtual IProfile2D * createProfile2D(const std::string & pathAndTitle, int nBinsX, double lowerEdgeX, double upperEdgeX, int nBinsY, double lowerEdgeY, double upperEdgeY) = 0;
 
     /**
      * Create a IProfile2D.
@@ -715,15 +587,7 @@ public:
      * @return             The newly created IProfile2D.
      *
      */
-  virtual IProfile2D * createProfile2D(const std::string & pathAndTitle, 
-				       int nBinsX, 
-				       double lowerEdgeX, 
-				       double upperEdgeX, 
-				       int nBinsY, 
-				       double lowerEdgeY, 
-				       double upperEdgeY, 
-				       double lowerValue, 
-				       double upperValue) = 0;
+    virtual IProfile2D * createProfile2D(const std::string & pathAndTitle, int nBinsX, double lowerEdgeX, double upperEdgeX, int nBinsY, double lowerEdgeY, double upperEdgeY, double lowerValue, double upperValue) = 0;
 
     /**
      * Create a copy of an IProfile2D.
@@ -735,8 +599,7 @@ public:
      * @return        The copy of the IProfile2D.
      *
      */
-  virtual IProfile2D * createCopy(const std::string & path, 
-				  const IProfile2D & profile) = 0;
+    virtual IProfile2D * createCopy(const std::string & path, const IProfile2D & profile) = 0;
 
     /**
      * Create an IHistogram1D by adding two IHistogram1D.
@@ -750,9 +613,7 @@ public:
      *              if a directory in the path does not exist, or the path is illegal.
      *
      */
-  virtual IHistogram1D * add(const std::string & path, 
-  			     const IHistogram1D & hist1, 
-  			     const IHistogram1D & hist2) = 0;
+    virtual IHistogram1D * add(const std::string & path, const IHistogram1D & hist1, const IHistogram1D & hist2) = 0;
 
     /**
      * Create an IHistogram1D by subtracting two IHistogram1D.
@@ -766,9 +627,7 @@ public:
      *              if a directory in the path does not exist, or the path is illegal.
      *
      */
-  virtual IHistogram1D * subtract(const std::string & path, 
-				  const IHistogram1D & hist1, 
-				  const IHistogram1D & hist2) = 0;
+    virtual IHistogram1D * subtract(const std::string & path, const IHistogram1D & hist1, const IHistogram1D & hist2) = 0;
 
     /**
      * Create an IHistogram1D by multiplying two IHistogram1D.
@@ -782,9 +641,7 @@ public:
      *              if a directory in the path does not exist, or the path is illegal.
      *
      */
-  virtual IHistogram1D * multiply(const std::string & path, 
-				  const IHistogram1D & hist1, 
-				  const IHistogram1D & hist2) = 0;
+    virtual IHistogram1D * multiply(const std::string & path, const IHistogram1D & hist1, const IHistogram1D & hist2) = 0;
 
     /**
      * Create an IHistogram1D by dividing two IHistogram1D.
@@ -798,9 +655,7 @@ public:
      *              if a directory in the path does not exist, or the path is illegal.
      *
      */
-  virtual IHistogram1D * divide(const std::string & path, 
-				const IHistogram1D & hist1, 
-				const IHistogram1D & hist2) = 0;
+    virtual IHistogram1D * divide(const std::string & path, const IHistogram1D & hist1, const IHistogram1D & hist2) = 0;
 
     /**
      * Create an IHistogram2D by adding two IHistogram2D.
@@ -814,9 +669,7 @@ public:
      *              if a directory in the path does not exist, or the path is illegal.
      *
      */
-  virtual IHistogram2D * add(const std::string & path, 
-			     const IHistogram2D & hist1, 
-			     const IHistogram2D & hist2) = 0;
+    virtual IHistogram2D * add(const std::string & path, const IHistogram2D & hist1, const IHistogram2D & hist2) = 0;
 
     /**
      * Create an IHistogram2D by subtracting two IHistogram2D.
@@ -830,9 +683,7 @@ public:
      *              if a directory in the path does not exist, or the path is illegal.
      *
      */
-  virtual IHistogram2D * subtract(const std::string & path, 
-				  const IHistogram2D & hist1, 
-				  const IHistogram2D & hist2) = 0;
+    virtual IHistogram2D * subtract(const std::string & path, const IHistogram2D & hist1, const IHistogram2D & hist2) = 0;
 
     /**
      * Create an IHistogram2D by multiplying two IHistogram2D.
@@ -846,9 +697,7 @@ public:
      *              if a directory in the path does not exist, or the path is illegal.
      *
      */
-  virtual IHistogram2D * multiply(const std::string & path, 
-				  const IHistogram2D & hist1, 
-				  const IHistogram2D & hist2) = 0;
+    virtual IHistogram2D * multiply(const std::string & path, const IHistogram2D & hist1, const IHistogram2D & hist2) = 0;
 
     /**
      * Create an IHistogram2D by dividing two IHistogram2D.
@@ -862,9 +711,7 @@ public:
      *              if a directory in the path does not exist, or the path is illegal.
      *
      */
-  virtual IHistogram2D * divide(const std::string & path, 
-				const IHistogram2D & hist1, 
-				const IHistogram2D & hist2) = 0;
+    virtual IHistogram2D * divide(const std::string & path, const IHistogram2D & hist1, const IHistogram2D & hist2) = 0;
 
     /**
      * Create an IHistogram3D by adding two IHistogram3D.
@@ -878,9 +725,7 @@ public:
      *              if a directory in the path does not exist, or the path is illegal.
      *
      */
-  virtual IHistogram3D * add(const std::string & path, 
-			     const IHistogram3D & hist1, 
-			     const IHistogram3D & hist2) = 0;
+    virtual IHistogram3D * add(const std::string & path, const IHistogram3D & hist1, const IHistogram3D & hist2) = 0;
 
     /**
      * Create an IHistogram3D by subtracting two IHistogram3D.
@@ -894,9 +739,7 @@ public:
      *              if a directory in the path does not exist, or the path is illegal.
      *
      */
-  virtual IHistogram3D * subtract(const std::string & path, 
-				  const IHistogram3D & hist1, 
-				  const IHistogram3D & hist2) = 0;
+    virtual IHistogram3D * subtract(const std::string & path, const IHistogram3D & hist1, const IHistogram3D & hist2) = 0;
 
     /**
      * Create an IHistogram3D by multiplying two IHistogram3D.
@@ -910,9 +753,7 @@ public:
      *              if a directory in the path does not exist, or the path is illegal.
      *
      */
-  virtual IHistogram3D * multiply(const std::string & path, 
-				  const IHistogram3D & hist1, 
-				  const IHistogram3D & hist2) = 0;
+    virtual IHistogram3D * multiply(const std::string & path, const IHistogram3D & hist1, const IHistogram3D & hist2) = 0;
 
     /**
      * Create an IHistogram3D by dividing two IHistogram3D.
@@ -926,9 +767,7 @@ public:
      *              if a directory in the path does not exist, or the path is illegal.
      *
      */
-  virtual IHistogram3D * divide(const std::string & path, 
-				const IHistogram3D & hist1, 
-				const IHistogram3D & hist2) = 0;
+    virtual IHistogram3D * divide(const std::string & path, const IHistogram3D & hist1, const IHistogram3D & hist2) = 0;
 
     /**
      * Create an IHistogram1D by projecting an IHistogram2D along its x axis.
@@ -941,8 +780,7 @@ public:
      * @return     The resulting projection.
      *
      */
-  virtual IHistogram1D * projectionX(const std::string & path, 
-				     const IHistogram2D & hist) = 0;
+    virtual IHistogram1D * projectionX(const std::string & path, const IHistogram2D & hist) = 0;
 
     /**
      * Create an IHistogram1D by projecting an IHistogram2D along its y axis.
@@ -955,8 +793,7 @@ public:
      * @return     The resulting projection.
      *
      */
-  virtual IHistogram1D * projectionY(const std::string & path, 
-				     const IHistogram2D & hist) = 0;
+    virtual IHistogram1D * projectionY(const std::string & path, const IHistogram2D & hist) = 0;
 
     /**
      * Create an IHistogram1D by slicing an IHistogram2D parallel to the y axis at a given bin.
@@ -970,9 +807,7 @@ public:
      * @return      The resulting slice.
      *
      */
-  virtual IHistogram1D * sliceX(const std::string & path, 
-				const IHistogram2D & hist, 
-				int index) = 0;
+    virtual IHistogram1D * sliceX(const std::string & path, const IHistogram2D & hist, int index) = 0;
 
     /**
      * Create an IHistogram1D by slicing an IHistogram2D parallel to the x axis at a given bin.
@@ -986,9 +821,7 @@ public:
      * @return      The resulting slice.
      *
      */
-  virtual IHistogram1D * sliceY(const std::string & path, 
-				const IHistogram2D & hist, 
-				int index) = 0;
+    virtual IHistogram1D * sliceY(const std::string & path, const IHistogram2D & hist, int index) = 0;
 
     /**
      * Create an IHistogram1D by slicing an IHistogram2D parallel to the y axis between two bins (inclusive).
@@ -1002,10 +835,7 @@ public:
      * @return       The resulting slice.
      *
      */
-  virtual IHistogram1D * sliceX(const std::string & path, 
-				const IHistogram2D & hist, 
-				int index1, 
-				int index2) = 0;
+    virtual IHistogram1D * sliceX(const std::string & path, const IHistogram2D & hist, int index1, int index2) = 0;
 
     /**
      * Create an IHistogram1D by slicing an IHistogram2D parallel to the x axis between two bins (inclusive).
@@ -1019,10 +849,7 @@ public:
      * @return       The resulting slice.
      *
      */
-  virtual IHistogram1D * sliceY(const std::string & path, 
-				const IHistogram2D & hist, 
-				int index1, 
-				int index2) = 0;
+    virtual IHistogram1D * sliceY(const std::string & path, const IHistogram2D & hist, int index1, int index2) = 0;
 
     /**
      * Create an IHistogram2D by projecting an IHistogram3D on the x-y plane.
@@ -1035,8 +862,7 @@ public:
      * @return     The resulting projection.
      *
      */
-  virtual IHistogram2D * projectionXY(const std::string & path, 
-				      const IHistogram3D & hist) = 0;
+    virtual IHistogram2D * projectionXY(const std::string & path, const IHistogram3D & hist) = 0;
 
     /**
      * Create an IHistogram2D by projecting an IHistogram3D on the x-z plane.
@@ -1049,8 +875,7 @@ public:
      * @return     The resulting projection.
      *
      */
-  virtual IHistogram2D * projectionXZ(const std::string & path, 
-				      const IHistogram3D & hist) = 0;
+    virtual IHistogram2D * projectionXZ(const std::string & path, const IHistogram3D & hist) = 0;
 
     /**
      * Create an IHistogram2D by projecting an IHistogram3D on the y-z plane.
@@ -1063,8 +888,7 @@ public:
      * @return     The resulting projection.
      *
      */
-  virtual IHistogram2D * projectionYZ(const std::string & path, 
-				      const IHistogram3D & hist) = 0;
+    virtual IHistogram2D * projectionYZ(const std::string & path, const IHistogram3D & hist) = 0;
 
     /**
      * Create an IHistogram2D by slicing an IHistogram3D perpendicular to the Z axis,
@@ -1101,10 +925,7 @@ public:
      * @return       The resulting slice.
      *
      */
-  virtual IHistogram2D * sliceXZ(const std::string & path, 
-				 const IHistogram3D & hist, 
-				 int index1, 
-				 int index2) = 0;
+    virtual IHistogram2D * sliceXZ(const std::string & path, const IHistogram3D & hist, int index1, int index2) = 0;
 
     /**
      * Create an IHistogram2D by slicing an IHistogram3D perpendicular to the X axis,
@@ -1121,10 +942,7 @@ public:
      * @return       The resulting slice.
      *
      */
-  virtual IHistogram2D * sliceYZ(const std::string & path, 
-				 const IHistogram3D & hist, 
-				 int index1, 
-				 int index2) = 0;
+    virtual IHistogram2D * sliceYZ(const std::string & path, const IHistogram3D & hist, int index1, int index2) = 0;
 }; // class
 } // namespace AIDA
 #endif /* ifndef AIDA_IHISTOGRAMFACTORY_H */

--- a/include/AIDA/IProfile1D.h
+++ b/include/AIDA/IProfile1D.h
@@ -97,7 +97,7 @@ public:
      * @param profile The IProfile1D to be added to this IProfile1D
      * @return false if profile binnings are incompatible
      */
-  /// virtual bool add(const IProfile1D & profile) = 0;
+    virtual bool add(const IProfile1D & profile) = 0;
 }; // class
 } // namespace AIDA
 #endif /* ifndef AIDA_IPROFILE1D_H */

--- a/include/AIDA/IProfile2D.h
+++ b/include/AIDA/IProfile2D.h
@@ -168,7 +168,7 @@ public:
      * @return false if the profile binnings are incompatible
      *
      */
-  /// virtual bool add(const IProfile2D & h) = 0;
+    virtual bool add(const IProfile2D & h) = 0;
 }; // class
 } // namespace AIDA
 #endif /* ifndef AIDA_IPROFILE2D_H */

--- a/include/AIDA/ITree.h
+++ b/include/AIDA/ITree.h
@@ -18,7 +18,7 @@
 
 namespace AIDA {
 
-  /// class IManagedObject;
+class IManagedObject;
 
 /**
  * User level interface to a Tree.
@@ -54,7 +54,7 @@ public:
    * @return     The corresponding IManagedObject.
    *
    */
-  /// virtual IManagedObject * find(const std::string & path) = 0;
+    virtual IManagedObject * find(const std::string & path) = 0;
 
   /**
    * Get a mounted ITree at a given path in the current ITree. The path can either be
@@ -63,7 +63,7 @@ public:
    * @return     The corresponding ITree.
    *
    */
-  /// virtual ITree * findTree(const std::string & path) = 0;
+    virtual ITree * findTree(const std::string & path) = 0;
 
   /**
    * Change to a given directory.
@@ -101,7 +101,7 @@ public:
    *                  in all the directories under path (the default is <code>false</code>.
    *
    */
-  /// virtual std::vector<std::string>  listObjectNames(const std::string & path = ".", bool recursive = false) const = 0;
+    virtual std::vector<std::string>  listObjectNames(const std::string & path = ".", bool recursive = false) const = 0;
 
   /**
    * Get the list of types of the IManagedObjects under a given path.
@@ -114,7 +114,7 @@ public:
    *                  in all the directories under path (the default is <code>false</code>.
    *
    */
-  /// virtual std::vector<std::string>  listObjectTypes(const std::string & path = ".", bool recursive = false) const = 0;
+    virtual std::vector<std::string>  listObjectTypes(const std::string & path = ".", bool recursive = false) const = 0;
 
   /**
    * Create a new directory. Given a path only the last directory
@@ -134,7 +134,7 @@ public:
    *             is not a directory, or if the directory already exists.
    *
    */
-  /// virtual bool mkdirs(const std::string & path) = 0;
+    virtual bool mkdirs(const std::string & path) = 0;
 
   /**
    * Remove a directory and all the contents underneeth.
@@ -143,7 +143,7 @@ public:
    *             a directory.
    *
    */
-  /// virtual bool rmdir(const std::string & path) = 0;
+    virtual bool rmdir(const std::string & path) = 0;
 
   /**
    * Remove an IManagedObject by specifying its path.
@@ -153,7 +153,7 @@ public:
    * @return false If path does not exist.
    *
    */
-  /// virtual bool rm(const std::string & path) = 0;
+    virtual bool rm(const std::string & path) = 0;
 
   /**
    * Get the full path of an IManagedObject.
@@ -162,7 +162,7 @@ public:
    *               In C++ if the object does not exist, an empty string is returned.
    *
    */
-  /// virtual std::string findPath(const IManagedObject & object) const = 0;
+    virtual std::string findPath(const IManagedObject & object) const = 0;
 
   /**
    * Move an IManagedObject or a directory from one directory to another.
@@ -171,7 +171,7 @@ public:
    * @return false If either path does not exist.
    *
    */
-  /// virtual bool mv(const std::string & oldPath, const std::string & newPath) = 0;
+    virtual bool mv(const std::string & oldPath, const std::string & newPath) = 0;
 
   /**
    * Commit any open transaction to the underlying store(s).
@@ -187,7 +187,7 @@ public:
    * @param overwrite <code>true</code> to enable overwriting.
    *
    */
-  /// virtual void setOverwrite(bool overwrite = true) = 0;
+    virtual void setOverwrite(bool overwrite = true) = 0;
 
   /**
    * Copy an object from a path to another.
@@ -197,7 +197,7 @@ public:
    * @return false If either path does not exist.
    *
    */
-  /// virtual bool cp(const std::string & oldPath, const std::string & newPath, bool recursive = false) = 0;
+    virtual bool cp(const std::string & oldPath, const std::string & newPath, bool recursive = false) = 0;
 
   /**
    * Create a symbolic link to an object in the ITree.
@@ -207,7 +207,7 @@ public:
    *              subidrectory within path does not exist.
    *
    */
-  /// virtual bool symlink(const std::string & path, const std::string & alias) = 0;
+    virtual bool symlink(const std::string & path, const std::string & alias) = 0;
 
   /**
    * Mounts a tree within another (target) tree. A tree can only be mounted once.
@@ -221,7 +221,7 @@ public:
    * @return false If something does not exist.
    *
    */
-  /// virtual bool mount(const std::string & path, ITree & tree, const std::string & treePath) = 0;
+    virtual bool mount(const std::string & path, ITree & tree, const std::string & treePath) = 0;
 
   /**
    * Unmount a subtree at a given path (mount point).
@@ -230,7 +230,7 @@ public:
    * @return false If path does not exist.
    *
    */
-  /// virtual bool unmount(const std::string & path) = 0;
+    virtual bool unmount(const std::string & path) = 0;
 
   /**
    * Closes the underlying store.
@@ -247,7 +247,7 @@ public:
    * @param className The name of the class to cast on.
    * @return The right pointer. Return 0 if failure.
    */ 
-  /// virtual void * cast(const std::string & className) const = 0;
+    virtual void * cast(const std::string & className) const = 0;
 }; // class
 } // namespace AIDA
 #endif /* ifndef AIDA_ITREE_H */

--- a/include/AIDA/ITuple.h
+++ b/include/AIDA/ITuple.h
@@ -63,7 +63,7 @@ public:
      * @return The ITuple's IAnnotation.
      *
      */
-  /// virtual IAnnotation & annotation() = 0;
+    virtual IAnnotation & annotation() = 0;
 
   /// virtual const IAnnotation & annotation() const = 0;
 
@@ -137,7 +137,7 @@ public:
      * @return false If the column is of the wrong type.
      *
      */
-  /// virtual bool fill(int column, const std::string & value) = 0;
+    virtual bool fill(int column, const std::string & value) = 0;
 
     /**
      * Fill a given column with an object.
@@ -146,7 +146,7 @@ public:
      * @return false If the column is of the wrong type.
      *
      */
-  /// virtual bool fill(int column, const ITupleEntry & value) = 0;
+    virtual bool fill(int column, const ITupleEntry & value) = 0;
 
     /**
      * Fill all the columns at once with doubles.
@@ -296,7 +296,7 @@ public:
      * @return       The string.
      *
      */    
-  /// virtual std::string getString(int column) const = 0;
+    virtual std::string getString(int column) const = 0;
 
     /**
      * Get the object stored in a given column at the current cursor's position.
@@ -304,7 +304,7 @@ public:
      * @return       The object.
      *
      */    
-  /// virtual const ITupleEntry * getObject(int column) const = 0;
+    virtual const ITupleEntry * getObject(int column) const = 0;
 
     /**
      * Return method for tuple variables of type ITuple for a given column.
@@ -313,9 +313,9 @@ public:
      * @return       The ITuple representing the structure of this column.
      *
      */
-  /// virtual const ITuple * getTuple(int column) const = 0;
+    virtual const ITuple * getTuple(int column) const = 0;
 
-  /// virtual ITuple * getTuple(int column) = 0;
+    virtual ITuple * getTuple(int column) = 0;
 
    /** 
     * Get the number of columns in the ITuple
@@ -899,7 +899,7 @@ public:
    * @param className The name of the class to cast on.
    * @return The right pointer. Return 0 if failure.
    */ 
-  /// virtual void * cast(const std::string & className) const = 0;
+    virtual void * cast(const std::string & className) const = 0;
 }; // class
 } // namespace AIDA
 #endif /* ifndef AIDA_ITUPLE_H */

--- a/include/AIDA/ITuple.h
+++ b/include/AIDA/ITuple.h
@@ -63,9 +63,9 @@ public:
      * @return The ITuple's IAnnotation.
      *
      */
-    virtual IAnnotation & annotation() = 0;
+  virtual IAnnotation & annotation() = 0;
 
-  /// virtual const IAnnotation & annotation() const = 0;
+  virtual const IAnnotation & annotation() const = 0;
 
     /**
      * Fill a given column with a double.

--- a/include/AIDA/ITupleFactory.h
+++ b/include/AIDA/ITupleFactory.h
@@ -58,10 +58,7 @@ public:
      * @param options NTuple options (currently undefined)
      *
      */
-  virtual ITuple * create(const std::string & path, 
-			  const std::string & title, 
-			  const std::string & columns, 
-			  const std::string & options = "") = 0;
+    virtual ITuple * create(const std::string & path, const std::string & title, const std::string & columns, const std::string & options = "") = 0;
 
     /**
      * Creates a logical chain of ITuples. All ITuples in the set must
@@ -75,7 +72,7 @@ public:
      * @param set   The array of ITuples to chain
      *
      */
-  ///virtual ITuple * createChained(const std::string & path, const std::string & title, const std::vector<ITuple *>  & set) = 0;
+    virtual ITuple * createChained(const std::string & path, const std::string & title, const std::vector<ITuple *>  & set) = 0;
 
     /**
      * Creates a logical chain of ITuples. All ITuples in the set must
@@ -89,7 +86,7 @@ public:
      * @param set   The array of the names of the ITuples to chain
      *
      */
-  ///virtual ITuple * createChained(const std::string & path, const std::string & title, const std::vector<std::string>  & set) = 0;
+    virtual ITuple * createChained(const std::string & path, const std::string & title, const std::vector<std::string>  & set) = 0;
 
     /**
      * Creates a new reduced tuple (less rows) from an existing one
@@ -102,7 +99,7 @@ public:
      * @param filter IFilter to be used
      *
      */
-  ///virtual ITuple * createFiltered(const std::string & path, ITuple & tuple, IFilter & filter) = 0;
+    virtual ITuple * createFiltered(const std::string & path, ITuple & tuple, IFilter & filter) = 0;
 
     /**
      * Creates a new reduced tuple (less rows) from an existing one
@@ -117,14 +114,14 @@ public:
      * @param columns Names of columns to for a new n-tuple
      *
      */
-  ///virtual ITuple * createFiltered(const std::string & path, ITuple & tuple, IFilter & filter, const std::vector<std::string>  & columns) = 0;
+    virtual ITuple * createFiltered(const std::string & path, ITuple & tuple, IFilter & filter, const std::vector<std::string>  & columns) = 0;
 
     /**
      * Creates IFilter object given a string defining of the "cut" expression.
      * @param expression String defining of the "cut" expression.
      *
      */
-  ///virtual IFilter * createFilter(const std::string & expression) = 0;
+    virtual IFilter * createFilter(const std::string & expression) = 0;
 
     /**
      * Creates a filter object given a string defining the "cut" expression.
@@ -134,14 +131,14 @@ public:
      * @param startingRow Row number where to start
      *
      */
-  ///virtual IFilter * createFilter(const std::string & expression, int rowsToProcess, int startingRow = 0) = 0;
+    virtual IFilter * createFilter(const std::string & expression, int rowsToProcess, int startingRow = 0) = 0;
 
     /**
      * Create IEvaluator object given its expression.
      * @param expression String defining of the evaluator expression.
      *
      */
-  ///virtual IEvaluator * createEvaluator(const std::string & expression) = 0;
+    virtual IEvaluator * createEvaluator(const std::string & expression) = 0;
 }; // class
 } // namespace AIDA
 #endif /* ifndef AIDA_ITUPLEFACTORY_H */

--- a/include/RAIDA/ICloud1DROOT.h
+++ b/include/RAIDA/ICloud1DROOT.h
@@ -195,9 +195,9 @@ public:
    * @return The IAnnotation.
    *
    */
-  /// virtual IAnnotation & annotation() ;
+  virtual IAnnotation & annotation() { throw std::runtime_error("Not implemented"); }
 
-  /// virtual const IAnnotation & annotation() const ;
+  virtual const IAnnotation & annotation() const { throw std::runtime_error("Not implemented"); }
 
   /**
    * Get the Histogram's dimension.

--- a/include/RAIDA/ICloud1DROOT.h
+++ b/include/RAIDA/ICloud1DROOT.h
@@ -112,7 +112,7 @@ public:
      * @return false If the ICloud1D has already been converted.
      *
      */
-  virtual bool convert(const std::vector<double>  & binEdges) {throw;};
+  virtual bool convert(const std::vector<double>  & binEdges) { throw std::runtime_error("Not implemented"); }
 
     /**
      * Get the internal IHistogram1D in which the ICloud1D converted to.
@@ -225,7 +225,7 @@ public:
    * @param className The name of the class to cast on.
    * @return The right pointer. Return 0 if failure.
    */ 
-  virtual void * cast(const std::string & className) const {throw;};
+  virtual void * cast(const std::string & className) const { throw std::runtime_error("Not implemented"); }
 
 private: 
 

--- a/include/RAIDA/ICloud1DROOT.h
+++ b/include/RAIDA/ICloud1DROOT.h
@@ -112,7 +112,7 @@ public:
      * @return false If the ICloud1D has already been converted.
      *
      */
-  /// virtual bool convert(const std::vector<double>  & binEdges) ;
+  virtual bool convert(const std::vector<double>  & binEdges) {throw;};
 
     /**
      * Get the internal IHistogram1D in which the ICloud1D converted to.
@@ -225,7 +225,7 @@ public:
    * @param className The name of the class to cast on.
    * @return The right pointer. Return 0 if failure.
    */ 
-  /// virtual void * cast(const std::string & className) const ;
+  virtual void * cast(const std::string & className) const {throw;};
 
 private: 
 

--- a/include/RAIDA/ICloud2DROOT.h
+++ b/include/RAIDA/ICloud2DROOT.h
@@ -167,7 +167,7 @@ public:
      * @return false If the ICloud2D has already been converted.
      *
      */
-  /// virtual bool convert(const std::vector<double>  & binEdgesX, const std::vector<double>  & binEdgesY) ;
+  virtual bool convert(const std::vector<double>  & binEdgesX, const std::vector<double>  & binEdgesY) {throw;}
 
     /**     
      * Get the internal IHistogram2D in which the ICloud2D converted to.
@@ -280,7 +280,7 @@ public:
    * @param className The name of the class to cast on.
    * @return The right pointer. Return 0 if failure.
    */ 
-  /// virtual void * cast(const std::string & className) const ;
+  virtual void * cast(const std::string & className) const {throw;}
 
 private:
 

--- a/include/RAIDA/ICloud2DROOT.h
+++ b/include/RAIDA/ICloud2DROOT.h
@@ -167,7 +167,7 @@ public:
      * @return false If the ICloud2D has already been converted.
      *
      */
-  virtual bool convert(const std::vector<double>  & binEdgesX, const std::vector<double>  & binEdgesY) {throw;}
+  virtual bool convert(const std::vector<double>  & binEdgesX, const std::vector<double>  & binEdgesY) { throw std::runtime_error("Not implemented"); }
 
     /**     
      * Get the internal IHistogram2D in which the ICloud2D converted to.
@@ -280,7 +280,7 @@ public:
    * @param className The name of the class to cast on.
    * @return The right pointer. Return 0 if failure.
    */ 
-  virtual void * cast(const std::string & className) const {throw;}
+  virtual void * cast(const std::string & className) const { throw std::runtime_error("Not implemented"); }
 
 private:
 

--- a/include/RAIDA/ICloud2DROOT.h
+++ b/include/RAIDA/ICloud2DROOT.h
@@ -250,9 +250,9 @@ public:
    * @return The IAnnotation.
    *
    */
-  /// virtual IAnnotation & annotation() ;
+  virtual IAnnotation & annotation() { throw std::runtime_error("Not implemented"); }
 
-  /// virtual const IAnnotation & annotation() const ;
+  virtual const IAnnotation & annotation() const { throw std::runtime_error("Not implemented"); }
 
   /**
    * Get the Histogram's dimension.

--- a/include/RAIDA/ICloud3DROOT.h
+++ b/include/RAIDA/ICloud3DROOT.h
@@ -299,9 +299,9 @@ public:
    * @return The IAnnotation.
    *
    */
-  /// virtual IAnnotation & annotation() ;
+  virtual IAnnotation & annotation() { throw std::runtime_error("Not implemented"); }
 
-  /// virtual const IAnnotation & annotation() const ;
+  virtual const IAnnotation & annotation() const { throw std::runtime_error("Not implemented"); }
 
   /**
    * Get the Histogram's dimension.

--- a/include/RAIDA/ICloud3DROOT.h
+++ b/include/RAIDA/ICloud3DROOT.h
@@ -216,7 +216,7 @@ public:
      * @return false If the ICloud3D has already been converted.
      *
      */
-  /// virtual bool convert(const std::vector<double>  & binEdgesX, const std::vector<double>  & binEdgesY, const std::vector<double>  & binEdgesZ) ;
+  virtual bool convert(const std::vector<double>  & binEdgesX, const std::vector<double>  & binEdgesY, const std::vector<double>  & binEdgesZ) {throw std::runtime_error("Not implemented");}
 
     /**     
      * Get the internal IHistogram3D in which the ICloud3D converted to.
@@ -329,7 +329,7 @@ public:
    * @param className The name of the class to cast on.
    * @return The right pointer. Return 0 if failure.
    */ 
-  /// virtual void * cast(const std::string & className) const ;
+  virtual void * cast(const std::string & className) const {throw std::runtime_error("Not implemented");}
 
 private:
 

--- a/include/RAIDA/IDataPointSetFactoryROOT.h
+++ b/include/RAIDA/IDataPointSetFactoryROOT.h
@@ -1,4 +1,5 @@
 // -*- C++ -*-
+#include <stdexcept>
 #ifndef AIDA_IDATAPOINTSETFACTORYROOT_H
 #define AIDA_IDATAPOINTSETFACTORYROOT_H 1
 #include <AIDA/IDataPointSetFactory.h>
@@ -47,7 +48,7 @@ public:
      * @return            The newly created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * create(const std::string & path, const std::string & title, int dimOfPoints) ;
+  virtual IDataPointSet * create(const std::string & path, const std::string & title, int dimOfPoints) {throw std::runtime_error("Not implemented");}
 
     /**
      * Create an empty IDataPointSet.
@@ -60,7 +61,7 @@ public:
      * @return             The newly created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * create(const std::string & pathAndTitle, int dimOfPoints) ;
+  virtual IDataPointSet * create(const std::string & pathAndTitle, int dimOfPoints) {throw std::runtime_error("Not implemented");}
 
     /**
      * Create a two dimensional IDataPointSet providing the data along y (the x value is 
@@ -75,7 +76,7 @@ public:
      * @return      The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createY(const std::string & path, const std::string & title, const std::vector<double>  & y, const std::vector<double>  & ey) ;
+  virtual IDataPointSet * createY(const std::string & path, const std::string & title, const std::vector<double>  & y, const std::vector<double>  & ey) {throw std::runtime_error("Not implemented");}
 
     /**
      * Create a two dimensional IDataPointSet providing the data along y (the x value is 
@@ -91,7 +92,7 @@ public:
      * @return      The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createY(const std::string & path, const std::string & title, const std::vector<double>  & y, const std::vector<double>  & eyp, const std::vector<double>  & eym) ;
+  virtual IDataPointSet * createY(const std::string & path, const std::string & title, const std::vector<double>  & y, const std::vector<double>  & eyp, const std::vector<double>  & eym) {throw std::runtime_error("Not implemented");}
 
     /**
      * Create a two dimensional IDataPointSet providing the data along y (the x value is 
@@ -106,7 +107,7 @@ public:
      * @return             The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createY(const std::string & pathAndTitle, const std::vector<double>  & y, const std::vector<double>  & ey) ;
+  virtual IDataPointSet * createY(const std::string & pathAndTitle, const std::vector<double>  & y, const std::vector<double>  & ey) {throw std::runtime_error("Not implemented");}
 
     /**
      * Create a two dimensional IDataPointSet providing the data along y (the x value is 
@@ -122,7 +123,7 @@ public:
      * @return             The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createY(const std::string & pathAndTitle, const std::vector<double>  & y, const std::vector<double>  & eyp, const std::vector<double>  & eym) ;
+  virtual IDataPointSet * createY(const std::string & pathAndTitle, const std::vector<double>  & y, const std::vector<double>  & eyp, const std::vector<double>  & eym) {throw std::runtime_error("Not implemented");}
 
     /**
      * Create a two dimensional IDataPointSet providing the data along x (the y value is 
@@ -137,7 +138,7 @@ public:
      * @return      The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createX(const std::string & path, const std::string & title, const std::vector<double>  & x, const std::vector<double>  & ex) ;
+  virtual IDataPointSet * createX(const std::string & path, const std::string & title, const std::vector<double>  & x, const std::vector<double>  & ex) {throw std::runtime_error("Not implemented");}
 
     /**
      * Create a two dimensional IDataPointSet providing the data along x (the y value is 
@@ -153,7 +154,7 @@ public:
      * @return      The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createX(const std::string & path, const std::string & title, const std::vector<double>  & x, const std::vector<double>  & exp, const std::vector<double>  & exm) ;
+  virtual IDataPointSet * createX(const std::string & path, const std::string & title, const std::vector<double>  & x, const std::vector<double>  & exp, const std::vector<double>  & exm) {throw std::runtime_error("Not implemented");}
 
     /**
      * Create a two dimensional IDataPointSet providing the data along x (the y value is 
@@ -168,7 +169,7 @@ public:
      * @return             The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createX(const std::string & pathAndTitle, const std::vector<double>  & x, const std::vector<double>  & ex) ;
+  virtual IDataPointSet * createX(const std::string & pathAndTitle, const std::vector<double>  & x, const std::vector<double>  & ex) {throw std::runtime_error("Not implemented");}
 
     /**
      * Create a two dimensional IDataPointSet providing the data along x (the y value is 
@@ -184,7 +185,7 @@ public:
      * @return             The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createX(const std::string & pathAndTitle, const std::vector<double>  & x, const std::vector<double>  & exp, const std::vector<double>  & exm) ;
+  virtual IDataPointSet * createX(const std::string & pathAndTitle, const std::vector<double>  & x, const std::vector<double>  & exp, const std::vector<double>  & exm) {throw std::runtime_error("Not implemented");}
 
     /**
      * Create a two dimensional IDataPointSet providing the data.
@@ -202,7 +203,7 @@ public:
      * @return      The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createXY(const std::string & path, const std::string & title, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & exp, const std::vector<double>  & eyp, const std::vector<double>  & exm, const std::vector<double>  & eym) ;
+  virtual IDataPointSet * createXY(const std::string & path, const std::string & title, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & exp, const std::vector<double>  & eyp, const std::vector<double>  & exm, const std::vector<double>  & eym) {throw std::runtime_error("Not implemented");}
 
     /**
      * Create a two dimensional IDataPointSet providing the data.
@@ -218,7 +219,7 @@ public:
      * @return      The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createXY(const std::string & path, const std::string & title, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & ex, const std::vector<double>  & ey) ;
+  virtual IDataPointSet * createXY(const std::string & path, const std::string & title, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & ex, const std::vector<double>  & ey) {throw std::runtime_error("Not implemented");}
 
     /**
      * Create a two dimensional IDataPointSet providing the data.
@@ -236,7 +237,7 @@ public:
      * @return             The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createXY(const std::string & pathAndTitle, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & exp, const std::vector<double>  & eyp, const std::vector<double>  & exm, const std::vector<double>  & eym) ;
+  virtual IDataPointSet * createXY(const std::string & pathAndTitle, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & exp, const std::vector<double>  & eyp, const std::vector<double>  & exm, const std::vector<double>  & eym) {throw std::runtime_error("Not implemented");}
 
     /**
      * Create a two dimensional IDataPointSet providing the data.
@@ -252,7 +253,7 @@ public:
      * @return             The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createXY(const std::string & pathAndTitle, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & ex, const std::vector<double>  & ey) ;
+  virtual IDataPointSet * createXY(const std::string & pathAndTitle, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & ex, const std::vector<double>  & ey) {throw std::runtime_error("Not implemented");}
 
     /**
      * Create a three dimensional IDataPointSet providing the data.
@@ -273,7 +274,7 @@ public:
      * @return      The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createXYZ(const std::string & path, const std::string & title, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & z, const std::vector<double>  & exp, const std::vector<double>  & eyp, const std::vector<double>  & ezp, const std::vector<double>  & exm, const std::vector<double>  & eym, const std::vector<double>  & ezm) ;
+  virtual IDataPointSet * createXYZ(const std::string & path, const std::string & title, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & z, const std::vector<double>  & exp, const std::vector<double>  & eyp, const std::vector<double>  & ezp, const std::vector<double>  & exm, const std::vector<double>  & eym, const std::vector<double>  & ezm) {throw std::runtime_error("Not implemented");}
 
     /**
      * Create a three dimensional IDataPointSet providing the data.
@@ -291,7 +292,7 @@ public:
      * @return      The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createXYZ(const std::string & path, const std::string & title, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & z, const std::vector<double>  & ex, const std::vector<double>  & ey, const std::vector<double>  & ez) ;
+  virtual IDataPointSet * createXYZ(const std::string & path, const std::string & title, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & z, const std::vector<double>  & ex, const std::vector<double>  & ey, const std::vector<double>  & ez) {throw std::runtime_error("Not implemented");}
 
     /**
      * Create a two dimensional IDataPointSet providing the data.
@@ -312,7 +313,7 @@ public:
      * @return             The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createXYZ(const std::string & pathAndTitle, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & z, const std::vector<double>  & exp, const std::vector<double>  & eyp, const std::vector<double>  & ezp, const std::vector<double>  & exm, const std::vector<double>  & eym, const std::vector<double>  & ezm) ;
+  virtual IDataPointSet * createXYZ(const std::string & pathAndTitle, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & z, const std::vector<double>  & exp, const std::vector<double>  & eyp, const std::vector<double>  & ezp, const std::vector<double>  & exm, const std::vector<double>  & eym, const std::vector<double>  & ezm) {throw std::runtime_error("Not implemented");}
 
     /**
      * Create a two dimensional IDataPointSet providing the data.
@@ -330,7 +331,7 @@ public:
      * @return             The created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createXYZ(const std::string & pathAndTitle, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & z, const std::vector<double>  & ex, const std::vector<double>  & ey, const std::vector<double>  & ez) ;
+  virtual IDataPointSet * createXYZ(const std::string & pathAndTitle, const std::vector<double>  & x, const std::vector<double>  & y, const std::vector<double>  & z, const std::vector<double>  & ex, const std::vector<double>  & ey, const std::vector<double>  & ez) {throw std::runtime_error("Not implemented");}
 
     /**
      * Make a copy of a given IDataPointSet.
@@ -342,7 +343,7 @@ public:
      * @return             The copy of the given IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * createCopy(const std::string & path, const IDataPointSet & dataPointSet) ;
+  virtual IDataPointSet * createCopy(const std::string & path, const IDataPointSet & dataPointSet) {throw std::runtime_error("Not implemented");}
 
     /**
      * Destroy a given IDataPointSet.
@@ -350,7 +351,7 @@ public:
      * @return false If dataPointSet cannot be destroyed.
      *
      */
-  ///virtual bool destroy(IDataPointSet * dataPointSet) ;
+  virtual bool destroy(IDataPointSet * dataPointSet) {throw std::runtime_error("Not implemented");}
 
     /**
      * Create an IDataPointSet from an IHistogram1D.
@@ -363,7 +364,7 @@ public:
      * @return        The newly created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * create(const std::string & path, const IHistogram1D & hist, const std::string & options = "") ;
+  virtual IDataPointSet * create(const std::string & path, const IHistogram1D & hist, const std::string & options = "") {throw std::runtime_error("Not implemented");}
 
     /**
      * Create an IDataPointSet from an IHistogram2D.
@@ -376,7 +377,7 @@ public:
      * @return        The newly created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * create(const std::string & path, const IHistogram2D & hist, const std::string & options = "") ;
+  virtual IDataPointSet * create(const std::string & path, const IHistogram2D & hist, const std::string & options = "") {throw std::runtime_error("Not implemented");}
 
     /**
      * Create an IDataPointSet from an IHistogram3D.
@@ -389,7 +390,7 @@ public:
      * @return        The newly created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * create(const std::string & path, const IHistogram3D & hist, const std::string & options = "") ;
+  virtual IDataPointSet * create(const std::string & path, const IHistogram3D & hist, const std::string & options = "") {throw std::runtime_error("Not implemented");}
 
     /**
      * Create an IDataPointSet from an ICloud1D.
@@ -402,7 +403,7 @@ public:
      * @return        The newly created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * create(const std::string & path, const ICloud1D & cloud, const std::string & options = "") ;
+  virtual IDataPointSet * create(const std::string & path, const ICloud1D & cloud, const std::string & options = "") {throw std::runtime_error("Not implemented");}
 
     /**
      * Create an IDataPointSet from an ICloud2D.
@@ -415,7 +416,7 @@ public:
      * @return        The newly created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * create(const std::string & path, const ICloud2D & cloud, const std::string & options = "") ;
+  virtual IDataPointSet * create(const std::string & path, const ICloud2D & cloud, const std::string & options = "") {throw std::runtime_error("Not implemented");}
 
     /**
      * Create an IDataPointSet from an ICloud3D.
@@ -428,7 +429,7 @@ public:
      * @return        The newly created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * create(const std::string & path, const ICloud3D & cloud, const std::string & options = "") ;
+  virtual IDataPointSet * create(const std::string & path, const ICloud3D & cloud, const std::string & options = "") {throw std::runtime_error("Not implemented");}
 
     /**
      * Create an IDataPointSet from an IProfile1D.
@@ -441,7 +442,7 @@ public:
      * @return        The newly created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * create(const std::string & path, const IProfile1D & profile, const std::string & options = "") ;
+  virtual IDataPointSet * create(const std::string & path, const IProfile1D & profile, const std::string & options = "") {throw std::runtime_error("Not implemented");}
 
     /**
      * Create an IDataPointSet from an IProfile2D.
@@ -454,7 +455,7 @@ public:
      * @return        The newly created IDataPointSet.
      *
      */
-  ///virtual IDataPointSet * create(const std::string & path, const IProfile2D & profile, const std::string & options = "") ;
+  virtual IDataPointSet * create(const std::string & path, const IProfile2D & profile, const std::string & options = "") {throw std::runtime_error("Not implemented");}
 
     /**
      * Add two IDataSetPoint, point by point and measurement by measurement.
@@ -467,7 +468,7 @@ public:
      *                      if a directory in the path does not exist, or the path is illegal.
      *
      */
-  ///virtual IDataPointSet * add(const std::string & path, const IDataPointSet & dataPointSet1, const IDataPointSet & dataPointSet2) ;
+  virtual IDataPointSet * add(const std::string & path, const IDataPointSet & dataPointSet1, const IDataPointSet & dataPointSet2) {throw std::runtime_error("Not implemented");}
 
     /**
      * Subtract two IDataSetPoint, point by point and measurement by measurement.
@@ -482,7 +483,7 @@ public:
      *                      if a directory in the path does not exist, or the path is illegal.
      *
      */
-  ///virtual IDataPointSet * subtract(const std::string & path, const IDataPointSet & dataPointSet1, const IDataPointSet & dataPointSet2) ;
+  virtual IDataPointSet * subtract(const std::string & path, const IDataPointSet & dataPointSet1, const IDataPointSet & dataPointSet2) {throw std::runtime_error("Not implemented");}
 
     /**
      * Multiply two IDataSetPoint, point by point and measurement by measurement.
@@ -497,7 +498,7 @@ public:
      *                      if a directory in the path does not exist, or the path is illegal.
      *
      */
-  ///virtual IDataPointSet * multiply(const std::string & path, const IDataPointSet & dataPointSet1, const IDataPointSet & dataPointSet2) ;
+  virtual IDataPointSet * multiply(const std::string & path, const IDataPointSet & dataPointSet1, const IDataPointSet & dataPointSet2) {throw std::runtime_error("Not implemented");}
 
     /**
      * Divide two IDataSetPoint, point by point and measurement by measurement.
@@ -512,7 +513,7 @@ public:
      *                      if a directory in the path does not exist, or the path is illegal.
      *
      */
-  ///virtual IDataPointSet * divide(const std::string & path, const IDataPointSet & dataPointSet1, const IDataPointSet & dataPointSet2) ;
+  virtual IDataPointSet * divide(const std::string & path, const IDataPointSet & dataPointSet1, const IDataPointSet & dataPointSet2) {throw std::runtime_error("Not implemented");}
 
     /**
      * Calculate weighted means of two IDataSetPoint, point by point and measurement by measurement.
@@ -527,7 +528,7 @@ public:
      *                      if a directory in the path does not exist, or the path is illegal.
      *
      */
-  ///virtual IDataPointSet * weightedMean(const std::string & path, const IDataPointSet & dataPointSet1, const IDataPointSet & dataPointSet2) ;
+  virtual IDataPointSet * weightedMean(const std::string & path, const IDataPointSet & dataPointSet1, const IDataPointSet & dataPointSet2) {throw std::runtime_error("Not implemented");}
 }; // class
 } // namespace AIDA
 #endif /* ifndef AIDA_IDATAPOINTSETFACTORYROOT_H */

--- a/include/RAIDA/IHistogram1DROOT.h
+++ b/include/RAIDA/IHistogram1DROOT.h
@@ -89,6 +89,15 @@ public:
   virtual bool setName(const std::string & name) ;
 
   /**
+   * Get the IAnnotation associated with the Histogram.
+   * @return The IAnnotation.
+   *
+   */
+  virtual IAnnotation & annotation() { throw std::runtime_error("Not implemented"); }
+
+  virtual const IAnnotation & annotation() const { throw std::runtime_error("Not implemented"); }
+
+  /**
    * Get the Histogram's dimension.
    * @return The Histogram's dimension.
    *

--- a/include/RAIDA/IHistogram1DROOT.h
+++ b/include/RAIDA/IHistogram1DROOT.h
@@ -7,6 +7,7 @@
 #include <RAIDA/IHistogram3DROOT.h>
 
 #include <vector>
+#include <stdexcept>
 #include <TH1D.h>
 #include <AIDA/IAxis.h>
 
@@ -108,6 +109,13 @@ public:
    */
   virtual int entries() const ;
 
+  /**
+   *  See IManagedObject for a description.
+   * @param className The name of the class to cast on.
+   * @return The right pointer. Return 0 if failure.
+   */ 
+  virtual void * cast(const std::string & className) const {throw std::runtime_error("Not implemented");}
+
 // ---------------------------------------------------------------------------
 // Functions from IHistogram.h 
 // ---------------------------------------------------------------------------
@@ -177,6 +185,13 @@ public:
    *
    */
   virtual bool scale(double scaleFactor) ;
+  
+  /**
+   * Number of equivalent entries, i.e. <tt>SUM[ weight ] ^ 2 / SUM[ weight^2 ]</tt>
+   * @return The number of equivalent entries.
+   *
+   */
+  virtual double equivalentBinEntries() const {throw std::runtime_error("Not implemented");}
 
 // ---------------------------------------------------------------------------
 // Functions from IHistogram1D.h 

--- a/include/RAIDA/IHistogram2DROOT.h
+++ b/include/RAIDA/IHistogram2DROOT.h
@@ -10,6 +10,7 @@
 #include <TH1D.h>
 #include <TH2D.h>
 #include <vector>
+#include <stdexcept>
 
 namespace AIDA {
 
@@ -246,7 +247,7 @@ public:
    * @return The IAnnotation.
    *
    */
-  /// virtual IAnnotation & annotation() ;
+  virtual IAnnotation & annotation() { throw std::runtime_error("Not implemented"); }
 
   /// virtual const IAnnotation & annotation() const = 0;
 
@@ -276,7 +277,7 @@ public:
    * @param className The name of the class to cast on.
    * @return The right pointer. Return 0 if failure.
    */ 
-  /// virtual void * cast(const std::string & className) const ;
+  virtual void * cast(const std::string & className) const { throw std::runtime_error("Not implemented"); }
 
 // ---------------------------------------------------------------------------
 // Functions from IHistogram.h
@@ -304,7 +305,7 @@ public:
      * @return The number of equivalent entries.
      *
      */
-  /// virtual double equivalentBinEntries() const ;
+  virtual double equivalentBinEntries() const { throw std::runtime_error("Not implemented"); }
 
     /**
      * Sum of in-range bin heights in the IHistogram,

--- a/include/RAIDA/IHistogram2DROOT.h
+++ b/include/RAIDA/IHistogram2DROOT.h
@@ -249,7 +249,7 @@ public:
    */
   virtual IAnnotation & annotation() { throw std::runtime_error("Not implemented"); }
 
-  /// virtual const IAnnotation & annotation() const = 0;
+  virtual const IAnnotation & annotation() const { throw std::runtime_error("Not implemented"); }
 
   /**
    * Get the Histogram's dimension.

--- a/include/RAIDA/IHistogram3DROOT.h
+++ b/include/RAIDA/IHistogram3DROOT.h
@@ -9,6 +9,7 @@
 #include <TH2D.h>
 #include <TH3D.h>
 #include <vector>
+#include <stdexcept>
 
 namespace AIDA {
 
@@ -340,7 +341,7 @@ public:
    * @param className The name of the class to cast on.
    * @return The right pointer. Return 0 if failure.
    */ 
-  /// virtual void * cast(const std::string & className) const ;
+  virtual void * cast(const std::string & className) const { throw std::runtime_error("Not implemented"); }
 
 // ---------------------------------------------------------------------------
 // Functions from IHistogram.h
@@ -368,7 +369,7 @@ public:
      * @return The number of equivalent entries.
      *
      */
-  /// virtual double equivalentBinEntries() const ;
+  virtual double equivalentBinEntries() const { throw std::runtime_error("Not implemented"); }
 
     /**
      * Sum of in-range bin heights in the IHistogram,

--- a/include/RAIDA/IHistogram3DROOT.h
+++ b/include/RAIDA/IHistogram3DROOT.h
@@ -311,9 +311,9 @@ public:
    * @return The IAnnotation.
    *
    */
-  /// virtual IAnnotation & annotation() ;
+  virtual IAnnotation & annotation() { throw std::runtime_error("Not implemented"); }
 
-  /// virtual const IAnnotation & annotation() const ;
+  virtual const IAnnotation & annotation() const { throw std::runtime_error("Not implemented"); }
 
   /**
    * Get the Histogram's dimension.

--- a/include/RAIDA/IProfile1DROOT.h
+++ b/include/RAIDA/IProfile1DROOT.h
@@ -6,6 +6,7 @@
 #include <AIDA/IAxis.h>
 
 #include <vector>
+#include <stdexcept>
 #include <TH1D.h>
 #include <TProfile.h>
 
@@ -126,7 +127,7 @@ public:
      * @param profile The IProfile1D to be added to this IProfile1D
      * @return false if profile binnings are incompatible
      */
-  /// virtual bool add(const IProfile1D & profile) ;
+  virtual bool add(const IProfile1D & profile) { throw std::runtime_error("Not implemented"); }
 
 // ----------------------------------------------------------------------------
 //  Functions from IHistogram.h
@@ -235,7 +236,7 @@ public:
    * @param className The name of the class to cast on.
    * @return The right pointer. Return 0 if failure.
    */ 
-  /// virtual void * cast(const std::string & className) const ;
+  virtual void * cast(const std::string & className) const { throw std::runtime_error("Not implemented"); }
 
 protected:
 

--- a/include/RAIDA/IProfile1DROOT.h
+++ b/include/RAIDA/IProfile1DROOT.h
@@ -206,9 +206,9 @@ public:
    * @return The IAnnotation.
    *
    */
-  /// virtual IAnnotation & annotation() ;
+  virtual IAnnotation & annotation() { throw std::runtime_error("Not implemented"); }
 
-  /// virtual const IAnnotation & annotation() const ;
+  virtual const IAnnotation & annotation() const { throw std::runtime_error("Not implemented"); }
 
   /**
    * Get the Histogram's dimension.

--- a/include/RAIDA/IProfile2DROOT.h
+++ b/include/RAIDA/IProfile2DROOT.h
@@ -7,6 +7,7 @@
 #include <AIDA/IAxis.h>
 
 #include <vector>
+#include <stdexcept>
 #include <TH2D.h>
 #include <TProfile2D.h>
 
@@ -206,7 +207,7 @@ public:
      * @return false if the profile binnings are incompatible
      *
      */
-  /// virtual bool add(const IProfile2D & h) ;
+  virtual bool add(const IProfile2D & h) { throw std::runtime_error("Not implemented"); }
 
 // ----------------------------------------------------------------------------
 //  Functions from IProfile.h
@@ -317,7 +318,7 @@ public:
    * @param className The name of the class to cast on.
    * @return The right pointer. Return 0 if failure.
    */ 
-  /// virtual void * cast(const std::string & className) const ;
+  virtual void * cast(const std::string & className) const { throw std::runtime_error("Not implemented"); }
 
 protected:
 

--- a/include/RAIDA/IProfile2DROOT.h
+++ b/include/RAIDA/IProfile2DROOT.h
@@ -288,9 +288,9 @@ public:
    * @return The IAnnotation.
    *
    */
-  /// virtual IAnnotation & annotation() ;
+  virtual IAnnotation & annotation() { throw std::runtime_error("Not implemented"); }
 
-  /// virtual const IAnnotation & annotation() const ;
+  virtual const IAnnotation & annotation() const { throw std::runtime_error("Not implemented"); }
 
   /**
    * Get the Histogram's dimension.

--- a/include/RAIDA/ITreeROOT.h
+++ b/include/RAIDA/ITreeROOT.h
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <stdexcept>
 #include <TFile.h>
 namespace AIDA {
 
@@ -67,7 +68,7 @@ public:
    * @return     The corresponding IManagedObject.
    *
    */
-  /// virtual IManagedObject * find(const std::string & path);
+  virtual IManagedObject * find(const std::string & path) { throw std::runtime_error("Not implemented"); }
 
   /**
    * Get a mounted ITree at a given path in the current ITree. The path can either be
@@ -76,7 +77,7 @@ public:
    * @return     The corresponding ITree.
    *
    */
-  /// virtual ITree * findTree(const std::string & path);
+  virtual ITree * findTree(const std::string & path) { throw std::runtime_error("Not implemented"); }
 
   /**
    * Change to a given directory.
@@ -116,7 +117,7 @@ public:
    *                  in all the directories under path (the default is <code>false</code>.
    *
    */
-  /// virtual std::vector<std::string>  listObjectNames(const std::string & path = ".", bool recursive = false) const;
+  virtual std::vector<std::string>  listObjectNames(const std::string & path = ".", bool recursive = false) const { throw std::runtime_error("Not implemented"); }
 
   /**
    * Get the list of types of the IManagedObjects under a given path.
@@ -129,7 +130,7 @@ public:
    *                  in all the directories under path (the default is <code>false</code>.
    *
    */
-  /// virtual std::vector<std::string>  listObjectTypes(const std::string & path = ".", bool recursive = false) const;
+  virtual std::vector<std::string>  listObjectTypes(const std::string & path = ".", bool recursive = false) const { throw std::runtime_error("Not implemented"); }
 
   /**
    * Create a new directory. Given a path only the last directory
@@ -149,7 +150,7 @@ public:
    *             is not a directory, or if the directory already exists.
    *
    */
-  /// virtual bool mkdirs(const std::string & path);
+  virtual bool mkdirs(const std::string & path) { throw std::runtime_error("Not implemented"); }
 
   /**
    * Remove a directory and all the contents underneeth.
@@ -158,7 +159,7 @@ public:
    *             a directory.
    *
    */
-  /// virtual bool rmdir(const std::string & path);
+  virtual bool rmdir(const std::string & path) { throw std::runtime_error("Not implemented"); }
 
   /**
    * Remove an IManagedObject by specifying its path.
@@ -168,7 +169,7 @@ public:
    * @return false If path does not exist.
    *
    */
-  /// virtual bool rm(const std::string & path);
+  virtual bool rm(const std::string & path) { throw std::runtime_error("Not implemented"); }
 
   /**
    * Get the full path of an IManagedObject.
@@ -177,7 +178,7 @@ public:
    *               In C++ if the object does not exist, an empty string is returned.
    *
    */
-  /// virtual std::string findPath(const IManagedObject & object) const;
+  virtual std::string findPath(const IManagedObject & object) const { throw std::runtime_error("Not implemented"); }
 
   /**
    * Move an IManagedObject or a directory from one directory to another.
@@ -186,7 +187,7 @@ public:
    * @return false If either path does not exist.
    *
    */
-  /// virtual bool mv(const std::string & oldPath, const std::string & newPath);
+  virtual bool mv(const std::string & oldPath, const std::string & newPath) { throw std::runtime_error("Not implemented"); }
 
   /**
    * Commit any open transaction to the underlying store(s).
@@ -202,7 +203,7 @@ public:
    * @param overwrite <code>true</code> to enable overwriting.
    *
    */
-  /// virtual void setOverwrite(bool overwrite = true);
+  virtual void setOverwrite(bool overwrite = true) { throw std::runtime_error("Not implemented"); }
 
   /**
    * Copy an object from a path to another.
@@ -212,7 +213,7 @@ public:
    * @return false If either path does not exist.
    *
    */
-  /// virtual bool cp(const std::string & oldPath, const std::string & newPath, bool recursive = false);
+  virtual bool cp(const std::string & oldPath, const std::string & newPath, bool recursive = false) { throw std::runtime_error("Not implemented"); }
 
   /**
    * Create a symbolic link to an object in the ITree.
@@ -222,7 +223,7 @@ public:
    *              subidrectory within path does not exist.
    *
    */
-  /// virtual bool symlink(const std::string & path, const std::string & alias);
+  virtual bool symlink(const std::string & path, const std::string & alias) { throw std::runtime_error("Not implemented"); }
 
   /**
    * Mounts a tree within another (target) tree. A tree can only be mounted once.
@@ -236,7 +237,7 @@ public:
    * @return false If something does not exist.
    *
    */
-  /// virtual bool mount(const std::string & path, ITree & tree, const std::string & treePath) ;
+  virtual bool mount(const std::string & path, ITree & tree, const std::string & treePath)  { throw std::runtime_error("Not implemented"); }
 
   /**
    * Unmount a subtree at a given path (mount point).
@@ -245,7 +246,7 @@ public:
    * @return false If path does not exist.
    *
    */
-  /// virtual bool unmount(const std::string & path);
+  virtual bool unmount(const std::string & path) { throw std::runtime_error("Not implemented"); }
 
   /**
    * Closes the underlying store.
@@ -262,7 +263,7 @@ public:
    * @param className The name of the class to cast on.
    * @return The right pointer. Return 0 if failure.
    */ 
-  /// virtual void * cast(const std::string & className) const;
+  virtual void * cast(const std::string & className) const { throw std::runtime_error("Not implemented"); }
 
 private:
 

--- a/include/RAIDA/ITupleFactoryROOT.h
+++ b/include/RAIDA/ITupleFactoryROOT.h
@@ -5,6 +5,7 @@
 #include <AIDA/ITupleFactory.h>
 #include <string>
 #include <vector>
+#include <stdexcept>
 
 namespace AIDA {
 
@@ -76,7 +77,7 @@ public:
      * @param set   The array of ITuples to chain
      *
      */
-  ///virtual ITuple * createChained(const std::string & path, const std::string & title, const std::vector<ITuple *>  & set) ;
+  virtual ITuple * createChained(const std::string & path, const std::string & title, const std::vector<ITuple *>  & set) { throw std::runtime_error("Not implemented"); }
 
     /**
      * Creates a logical chain of ITuples. All ITuples in the set must
@@ -90,7 +91,7 @@ public:
      * @param set   The array of the names of the ITuples to chain
      *
      */
-  ///virtual ITuple * createChained(const std::string & path, const std::string & title, const std::vector<std::string>  & set) ;
+  virtual ITuple * createChained(const std::string & path, const std::string & title, const std::vector<std::string>  & set) { throw std::runtime_error("Not implemented"); }
 
     /**
      * Creates a new reduced tuple (less rows) from an existing one
@@ -103,7 +104,7 @@ public:
      * @param filter IFilter to be used
      *
      */
-  ///virtual ITuple * createFiltered(const std::string & path, ITuple & tuple, IFilter & filter) ;
+  virtual ITuple * createFiltered(const std::string & path, ITuple & tuple, IFilter & filter) { throw std::runtime_error("Not implemented"); }
 
     /**
      * Creates a new reduced tuple (less rows) from an existing one
@@ -118,14 +119,14 @@ public:
      * @param columns Names of columns to for a new n-tuple
      *
      */
-  ///virtual ITuple * createFiltered(const std::string & path, ITuple & tuple, IFilter & filter, const std::vector<std::string>  & columns) ;
+  virtual ITuple * createFiltered(const std::string & path, ITuple & tuple, IFilter & filter, const std::vector<std::string>  & columns) { throw std::runtime_error("Not implemented"); }
 
     /**
      * Creates IFilter object given a string defining of the "cut" expression.
      * @param expression String defining of the "cut" expression.
      *
      */
-  ///virtual IFilter * createFilter(const std::string & expression) ;
+  virtual IFilter * createFilter(const std::string & expression) { throw std::runtime_error("Not implemented"); }
 
     /**
      * Creates a filter object given a string defining the "cut" expression.
@@ -135,14 +136,14 @@ public:
      * @param startingRow Row number where to start
      *
      */
-  /// virtual IFilter * createFilter(const std::string & expression, int rowsToProcess, int startingRow = 0) ;
+  virtual IFilter * createFilter(const std::string & expression, int rowsToProcess, int startingRow = 0) { throw std::runtime_error("Not implemented"); }
 
     /**
      * Create IEvaluator object given its expression.
      * @param expression String defining of the evaluator expression.
      *
      */
-  ///virtual IEvaluator * createEvaluator(const std::string & expression) ;
+  virtual IEvaluator * createEvaluator(const std::string & expression) { throw std::runtime_error("Not implemented"); }
 
 private:
 

--- a/include/RAIDA/ITupleROOT.h
+++ b/include/RAIDA/ITupleROOT.h
@@ -68,7 +68,7 @@ public:
      */
   virtual IAnnotation & annotation() { throw std::runtime_error("Not implemented"); }
 
-  /// virtual const IAnnotation & annotation() const ;
+  virtual const IAnnotation & annotation() const { throw std::runtime_error("Not implemented"); }
 
     /**
      * Fill a given column with a double.

--- a/include/RAIDA/ITupleROOT.h
+++ b/include/RAIDA/ITupleROOT.h
@@ -6,6 +6,7 @@
 #include <TTree.h>
 #include <string>
 #include <vector>
+#include <stdexcept>
 #include <RAIDA/LeafPoint.h>
 
 namespace AIDA {
@@ -65,7 +66,7 @@ public:
      * @return The ITuple's IAnnotation.
      *
      */
-  /// virtual IAnnotation & annotation() ;
+  virtual IAnnotation & annotation() { throw std::runtime_error("Not implemented"); }
 
   /// virtual const IAnnotation & annotation() const ;
 
@@ -139,7 +140,7 @@ public:
      * @return false If the column is of the wrong type.
      *
      */
-  /// virtual bool fill(int column, const std::string & value) ;
+  virtual bool fill(int column, const std::string & value) { throw std::runtime_error("Not implemented"); }
 
     /**
      * Fill a given column with an object.
@@ -148,7 +149,7 @@ public:
      * @return false If the column is of the wrong type.
      *
      */
-  /// virtual bool fill(int column, const ITupleEntry & value) ;
+  virtual bool fill(int column, const ITupleEntry & value) { throw std::runtime_error("Not implemented"); }
 
     /**
      * Fill all the columns at once with doubles.
@@ -299,7 +300,7 @@ public:
      * @return       The string.
      *
      */    
-  /// virtual std::string getString(int column) const ;
+  virtual std::string getString(int column) const { throw std::runtime_error("Not implemented"); }
 
     /**
      * Get the object stored in a given column at the current cursor's position.
@@ -307,7 +308,7 @@ public:
      * @return       The object.
      *
      */    
-  /// virtual const ITupleEntry * getObject(int column) const ;
+  virtual const ITupleEntry * getObject(int column) const { throw std::runtime_error("Not implemented"); }
 
     /**
      * Return method for tuple variables of type ITuple for a given column.
@@ -316,9 +317,9 @@ public:
      * @return       The ITuple representing the structure of this column.
      *
      */
-  /// virtual const ITuple * getTuple(int column) const ;
+  virtual const ITuple * getTuple(int column) const { throw std::runtime_error("Not implemented"); }
 
-  /// virtual ITuple * getTuple(int column) ;
+  virtual ITuple * getTuple(int column) { throw std::runtime_error("Not implemented"); }
 
    /** 
     * Get the number of columns in the ITuple
@@ -902,7 +903,7 @@ public:
    * @param className The name of the class to cast on.
    * @return The right pointer. Return 0 if failure.
    */ 
-  /// virtual void * cast(const std::string & className) const ;
+  virtual void * cast(const std::string & className) const { throw std::runtime_error("Not implemented"); }
 
 protected:
 


### PR DESCRIPTION
This repository provides a modified version of the AIDA headers calling them also AIDA which is a problem in some situations in the key4hep stack, as we ship two different versions of the AIDA headers. This PR has semi-automatic changes to make the headers compatible with the AIDA ones while implementing the relevant interfaces that now throw (and they can't be used anywhere else). All the new ones have the same implementation:
``` c++
{ throw std::runtime_error("Not implemented"); }
```
Later I realised there is a `NotYetImplementedException` but I guess these will never be implemented so "Not implemented" fits better; it should be easy to change though.