### PR TITLE
Check for the Config.cmake and LibDeps.cmake in lib/cmake first

### DIFF
--- a/cmake/AIDAConfig.cmake.in
+++ b/cmake/AIDAConfig.cmake.in
@@ -3,7 +3,11 @@
 # @author Jan Engels, Desy
 ##############################################################################
 
-INCLUDE( "@CMAKE_INSTALL_PREFIX@/RAIDAConfig.cmake" )
+
+INCLUDE( "@CMAKE_INSTALL_PREFIX@/lib/cmake/RAIDA/RAIDAConfig.cmake" OPTIONAL RESULT_VARIABLE RAIDA_CONFIG_INCLUDED )
+IF( RAIDA_CONFIG_INCLUDED STREQUAL "NOTFOUND" )
+  INCLUDE( "@CMAKE_INSTALL_PREFIX@/RAIDAConfig.cmake" )
+ENDIF()
 
 SET( AIDA_FOUND ${RAIDA_FOUND} )
 

--- a/cmake/RAIDAConfig.cmake.in
+++ b/cmake/RAIDAConfig.cmake.in
@@ -53,7 +53,10 @@ CHECK_PACKAGE_LIBS( RAIDA RAIDA )
 
 # ---------- libraries dependencies -------------------------------------------
 # this sets RAIDA_${COMPONENT}_LIB_DEPENDS variables
-INCLUDE( "${RAIDA_ROOT}/lib/cmake/RAIDALibDeps.cmake" )
+INCLUDE( "${RAIDA_ROOT}/lib/cmake/RAIDA/RAIDALibDeps.cmake" OPTIONAL RESULT_VARIABLE RAIDA_LIBDEPS_INCLUDED )
+IF( RAIDA_LIBDEPS_INCLUDED STREQUAL "NOTFOUND" )
+    INCLUDE( "${RAIDA_ROOT}/lib/cmake/RAIDALibDeps.cmake" )
+ENDIF()
  
 
 


### PR DESCRIPTION
before the root installation folder. This change works with the existing version of iLCUtil and also with a future change where the Config files are installed to lib/cmake instead of the root of the installation folder. See https://github.com/iLCSoft/iLCUtil/pull/36. See also the documentation on include to see what the arguments do: https://cmake.org/cmake/help/latest/command/include.html.

BEGINRELEASENOTES
- Check for the Config.cmake and LibDeps.cmake in lib/cmake first in case it is installed there instead of the usual root of the installation folder.

ENDRELEASENOTES

I think how this can be better implemented is to merge this, let the nightlies build and then merge https://github.com/iLCSoft/iLCUtil/pull/36.