### PR TITLE
Create a symbolic link to make find_package(AIDA) work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,9 @@ DISPLAY_STD_VARIABLES()
 GENERATE_PACKAGE_CONFIGURATION_FILES( RAIDAConfig.cmake RAIDAConfigVersion.cmake AIDAConfig.cmake AIDAConfigVersion.cmake RAIDALibDeps.cmake )
 
 # Make a symbolic link in lib/cmake from RAIDA to AIDA to make sure that find_package(AIDA) works
-# Make sure the target directory exists
-FILE( MAKE_DIRECTORY "${CMAKE_INSTALL_PREFIX}/lib/cmake" )
-EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_INSTALL_PREFIX}/lib/cmake/RAIDA" "${CMAKE_INSTALL_PREFIX}/lib/cmake/AIDA" )
+install(CODE "
+if(EXISTS \"${CMAKE_INSTALL_PREFIX}/lib/cmake/RAIDA\")
+  execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink \"${CMAKE_INSTALL_PREFIX}/lib/cmake/RAIDA\" \"${CMAKE_INSTALL_PREFIX}/lib/cmake/AIDA\")
+endif()
+")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,5 +95,7 @@ DISPLAY_STD_VARIABLES()
 GENERATE_PACKAGE_CONFIGURATION_FILES( RAIDAConfig.cmake RAIDAConfigVersion.cmake AIDAConfig.cmake AIDAConfigVersion.cmake RAIDALibDeps.cmake )
 
 # Make a symbolic link in lib/cmake from RAIDA to AIDA to make sure that find_package(AIDA) works
+# Make sure the target directory exists
+FILE( MAKE_DIRECTORY "${CMAKE_INSTALL_PREFIX}/lib/cmake" )
 EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_INSTALL_PREFIX}/lib/cmake/RAIDA" "${CMAKE_INSTALL_PREFIX}/lib/cmake/AIDA" )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,3 +94,6 @@ DISPLAY_STD_VARIABLES()
 # generate and install following configuration files
 GENERATE_PACKAGE_CONFIGURATION_FILES( RAIDAConfig.cmake RAIDAConfigVersion.cmake AIDAConfig.cmake AIDAConfigVersion.cmake RAIDALibDeps.cmake )
 
+# Make a symbolic link in lib/cmake from RAIDA to AIDA to make sure that find_package(AIDA) works
+EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_INSTALL_PREFIX}/lib/cmake/RAIDA" "${CMAKE_INSTALL_PREFIX}/lib/cmake/AIDA" )
+


### PR DESCRIPTION
After https://github.com/iLCSoft/iLCUtil/pull/36, `Config.cmake` and other files will be installed to `<prefix>/lib/cmake/RAIDA` as `RAIDA` is the name of the package. However, `find_package(AIDA)` will look into `<prefix>/lib/cmake/AIDA` which will not exist and this call will fail. With a symbolic link, there will be a way to look into this folder, and if the folder is not created the symbolic link is not created (before https://github.com/iLCSoft/iLCUtil/pull/36).

BEGINRELEASENOTES
- Create a symbolic link to make `find_package(AIDA)` work

ENDRELEASENOTES