### PR TITLE
Define AIDA_HAS_CAST to avoid warning in Gaudi.

### DIFF
--- a/include/AIDA/IBaseHistogram.h
+++ b/include/AIDA/IBaseHistogram.h
@@ -14,6 +14,12 @@
 
 #include <string>
 
+// This tells Gaudi that we declare IBaseHistogram::cast as a virtual method.
+// Gaudi overrides it in a derived class, and having this macro defined
+// causes it to use the override keyword to avoid warnings about
+// inconsistent use of override.
+#define AIDA_HAS_CAST
+
 namespace AIDA {
 
 class IAnnotation;


### PR DESCRIPTION
We declare IBaseHistogram::cast as a virtual method, and Gaudi overrides it in a derived class.  Defining AIDA_HAS_CAST tells Gaudi to use the override keyword for that method, as it does for other methods, to avoid warnings about inconsistent use of override.