### PR TITLE
Make the symbolic link relative so that it works after relocating

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ GENERATE_PACKAGE_CONFIGURATION_FILES( RAIDAConfig.cmake RAIDAConfigVersion.cmake
 # Make a symbolic link in lib/cmake from RAIDA to AIDA to make sure that find_package(AIDA) works
 install(CODE "
 if(EXISTS \"${CMAKE_INSTALL_PREFIX}/lib/cmake/RAIDA\")
-  execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink \"${CMAKE_INSTALL_PREFIX}/lib/cmake/RAIDA\" \"${CMAKE_INSTALL_PREFIX}/lib/cmake/AIDA\")
+  execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink \"RAIDA\" \"${CMAKE_INSTALL_PREFIX}/lib/cmake/AIDA\")
 endif()
 ")
 


### PR DESCRIPTION
currently in LCG stacks absolute symlinks seem not to get relocated so in the installation folder they point to the non-existing build folder.

BEGINRELEASENOTES
- Make the AIDA symbolic link be relative and point to RAIDA in the same directory, to make it work even when the installation is relocated and the symlink is not modified.

ENDRELEASENOTES
